### PR TITLE
Unify text handling

### DIFF
--- a/Callbacks.py
+++ b/Callbacks.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 
 from . import Locations
 from .Rac2Interface import Rac2Planet
-from .TextManager import TextManager, get_formatted_item_name
+from .TextManager import TextManager, get_rich_item_name_from_location
 from .data import Items
 
 if TYPE_CHECKING:
@@ -68,75 +68,75 @@ def replace_text(ctx: 'Rac2Context', ap_connected: bool):
             return
 
         if ctx.current_planet is Rac2Planet.Oozla:
-            item_name = get_formatted_item_name(ctx, Locations.OOZLA_MEGACORP_SCIENTIST.location_id)
+            item_name = get_rich_item_name_from_location(ctx, Locations.OOZLA_MEGACORP_SCIENTIST.location_id)
             manager.inject(0x27AE, f"You need %d bolts for {item_name}")
             manager.inject(0x27AC, f"\x12 Buy {item_name} for %d bolts")
 
         elif ctx.current_planet is Rac2Planet.Maktar_Nebula:
-            item_name = get_formatted_item_name(ctx, Locations.MAKTAR_ARENA_CHALLENGE.location_id)
+            item_name = get_rich_item_name_from_location(ctx, Locations.MAKTAR_ARENA_CHALLENGE.location_id)
             manager.inject(0x2F46, f"You have earned {item_name}")
 
         elif ctx.current_planet is Rac2Planet.Barlow:
-            item_name = get_formatted_item_name(ctx, Locations.BARLOW_INVENTOR.location_id)
+            item_name = get_rich_item_name_from_location(ctx, Locations.BARLOW_INVENTOR.location_id)
             manager.inject(0x27A0, f"You need %d bolts for {item_name}")
             manager.inject(0x279F, f"\x12 Buy {item_name} for %d bolts")
 
         elif ctx.current_planet is Rac2Planet.Feltzin_System:
-            item_name = get_formatted_item_name(ctx, Locations.FELTZIN_DEFEAT_THUG_SHIPS.location_id)
+            item_name = get_rich_item_name_from_location(ctx, Locations.FELTZIN_DEFEAT_THUG_SHIPS.location_id)
             manager.inject(0x11F5, f"Received {item_name}")
-            item_name = get_formatted_item_name(ctx, Locations.FELTZIN_RACE_PB.location_id)
+            item_name = get_rich_item_name_from_location(ctx, Locations.FELTZIN_RACE_PB.location_id)
             manager.inject(0x2FDF, f"Perfect Ring Bonus: {item_name}")
 
         elif ctx.current_planet is Rac2Planet.Notak:
-            item_name = get_formatted_item_name(ctx, Locations.NOTAK_WORKER_BOTS.location_id)
+            item_name = get_rich_item_name_from_location(ctx, Locations.NOTAK_WORKER_BOTS.location_id)
             manager.inject(0x27CE, f"You need %d bolts for {item_name}")
             manager.inject(0x27CF, f"\x12 Buy {item_name} for %d bolts")
 
         elif ctx.current_planet is Rac2Planet.Hrugis_Cloud:
-            item_name = get_formatted_item_name(ctx, Locations.HRUGIS_DESTROY_DEFENSES.location_id)
+            item_name = get_rich_item_name_from_location(ctx, Locations.HRUGIS_DESTROY_DEFENSES.location_id)
             manager.inject(0x11FB, f"Received {item_name}")
-            item_name = get_formatted_item_name(ctx, Locations.HRUGIS_RACE_PB.location_id)
+            item_name = get_rich_item_name_from_location(ctx, Locations.HRUGIS_RACE_PB.location_id)
             manager.inject(0x2FEB, f"Perfect Ring Bonus: {item_name}")
 
         elif ctx.current_planet is Rac2Planet.Joba:
-            item_name = get_formatted_item_name(ctx, Locations.JOBA_SHADY_SALESMAN.location_id)
+            item_name = get_rich_item_name_from_location(ctx, Locations.JOBA_SHADY_SALESMAN.location_id)
             manager.inject(0x27BB, f"\x12 Buy {item_name} for %d bolts")
             manager.inject(0x27BC, f"You need %d bolts for {item_name}")
-            item_name = get_formatted_item_name(ctx, Locations.JOBA_ARENA_BATTLE.location_id)
+            item_name = get_rich_item_name_from_location(ctx, Locations.JOBA_ARENA_BATTLE.location_id)
             manager.inject(0x2F66, f"Battle for {item_name}")
             manager.inject(0x2F96, f"You have earned {item_name}")
-            item_name = get_formatted_item_name(ctx, Locations.JOBA_ARENA_CAGE_MATCH.location_id)
+            item_name = get_rich_item_name_from_location(ctx, Locations.JOBA_ARENA_CAGE_MATCH.location_id)
             manager.inject(0x2F67, f"Cage Match for {item_name}")
             manager.inject(0x2F97, f"You have earned {item_name}")
 
         elif ctx.current_planet is Rac2Planet.Todano:
-            item_name = get_formatted_item_name(ctx, Locations.TODANO_STUART_ZURGO_TRADE.location_id)
+            item_name = get_rich_item_name_from_location(ctx, Locations.TODANO_STUART_ZURGO_TRADE.location_id)
             manager.inject(0x27D3, f"You need the Qwark action figure for {item_name}")
             manager.inject(0x27D4, f"Trade Qwark action figure for {item_name}")
 
         elif ctx.current_planet is Rac2Planet.Aranos_Prison:
-            item_name = get_formatted_item_name(ctx, Locations.ARANOS_PLUMBER.location_id)
+            item_name = get_rich_item_name_from_location(ctx, Locations.ARANOS_PLUMBER.location_id)
             manager.inject(0x27D5, f"You need %d bolts for {item_name}")
             manager.inject(0x27D6, f"\x12 Buy {item_name} for %d bolts")
 
         elif ctx.current_planet is Rac2Planet.Gorn:
-            item_name = get_formatted_item_name(ctx, Locations.GORN_DEFEAT_THUG_FLEET.location_id)
+            item_name = get_rich_item_name_from_location(ctx, Locations.GORN_DEFEAT_THUG_FLEET.location_id)
             manager.inject(0x11FF, f"Received {item_name}")
-            item_name = get_formatted_item_name(ctx, Locations.GORN_RACE_PB.location_id)
+            item_name = get_rich_item_name_from_location(ctx, Locations.GORN_RACE_PB.location_id)
             manager.inject(0x2FF2, f"Perfect Ring Bonus: {item_name}")
 
         elif ctx.current_planet is Rac2Planet.Smolg:
-            item_name = get_formatted_item_name(ctx, Locations.SMOLG_MUTANT_CRAB.location_id)
+            item_name = get_rich_item_name_from_location(ctx, Locations.SMOLG_MUTANT_CRAB.location_id)
             manager.inject(0x27D7, f"You need %d bolts for {item_name}")
             manager.inject(0x27D8, f"\x12 Buy {item_name} for %d bolts")
 
         elif ctx.current_planet is Rac2Planet.Damosel:
-            item_name = get_formatted_item_name(ctx, Locations.DAMOSEL_HYPNOTIST.location_id)
+            item_name = get_rich_item_name_from_location(ctx, Locations.DAMOSEL_HYPNOTIST.location_id)
             manager.inject(0x27DA, f"You need %d bolts for {item_name}")
             manager.inject(0x27DB, f"\x12 Trade parts and %d bolts for {item_name}")
 
         elif ctx.current_planet is Rac2Planet.Grelbin:
-            item_name = get_formatted_item_name(ctx, Locations.GRELBIN_MYSTIC_MORE_MOONSTONES.location_id)
+            item_name = get_rich_item_name_from_location(ctx, Locations.GRELBIN_MYSTIC_MORE_MOONSTONES.location_id)
             manager.inject(0x27DE, f"You need 16 \x0CMoonstones\x08 for {item_name}")
             manager.inject(0x27DF, f"\x12 Trade 16 \x0CMoonstones\x08 for {item_name}")
     except TypeError:

--- a/Callbacks.py
+++ b/Callbacks.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 
 from . import Locations
 from .Rac2Interface import Rac2Planet
-from .TextManager import TextManager
+from .TextManager import TextManager, get_formatted_item_name
 from .data import Items
 
 if TYPE_CHECKING:
@@ -68,75 +68,75 @@ def replace_text(ctx: 'Rac2Context', ap_connected: bool):
             return
 
         if ctx.current_planet is Rac2Planet.Oozla:
-            item_name = manager.get_formatted_item_name(Locations.OOZLA_MEGACORP_SCIENTIST.location_id)
+            item_name = get_formatted_item_name(ctx, Locations.OOZLA_MEGACORP_SCIENTIST.location_id)
             manager.inject(0x27AE, f"You need %d bolts for {item_name}")
             manager.inject(0x27AC, f"\x12 Buy {item_name} for %d bolts")
 
         elif ctx.current_planet is Rac2Planet.Maktar_Nebula:
-            item_name = manager.get_formatted_item_name(Locations.MAKTAR_ARENA_CHALLENGE.location_id)
+            item_name = get_formatted_item_name(ctx, Locations.MAKTAR_ARENA_CHALLENGE.location_id)
             manager.inject(0x2F46, f"You have earned {item_name}")
 
         elif ctx.current_planet is Rac2Planet.Barlow:
-            item_name = manager.get_formatted_item_name(Locations.BARLOW_INVENTOR.location_id)
+            item_name = get_formatted_item_name(ctx, Locations.BARLOW_INVENTOR.location_id)
             manager.inject(0x27A0, f"You need %d bolts for {item_name}")
             manager.inject(0x279F, f"\x12 Buy {item_name} for %d bolts")
 
         elif ctx.current_planet is Rac2Planet.Feltzin_System:
-            item_name = manager.get_formatted_item_name(Locations.FELTZIN_DEFEAT_THUG_SHIPS.location_id)
+            item_name = get_formatted_item_name(ctx, Locations.FELTZIN_DEFEAT_THUG_SHIPS.location_id)
             manager.inject(0x11F5, f"Received {item_name}")
-            item_name = manager.get_formatted_item_name(Locations.FELTZIN_RACE_PB.location_id)
+            item_name = get_formatted_item_name(ctx, Locations.FELTZIN_RACE_PB.location_id)
             manager.inject(0x2FDF, f"Perfect Ring Bonus: {item_name}")
 
         elif ctx.current_planet is Rac2Planet.Notak:
-            item_name = manager.get_formatted_item_name(Locations.NOTAK_WORKER_BOTS.location_id)
+            item_name = get_formatted_item_name(ctx, Locations.NOTAK_WORKER_BOTS.location_id)
             manager.inject(0x27CE, f"You need %d bolts for {item_name}")
             manager.inject(0x27CF, f"\x12 Buy {item_name} for %d bolts")
 
         elif ctx.current_planet is Rac2Planet.Hrugis_Cloud:
-            item_name = manager.get_formatted_item_name(Locations.HRUGIS_DESTROY_DEFENSES.location_id)
+            item_name = get_formatted_item_name(ctx, Locations.HRUGIS_DESTROY_DEFENSES.location_id)
             manager.inject(0x11FB, f"Received {item_name}")
-            item_name = manager.get_formatted_item_name(Locations.HRUGIS_RACE_PB.location_id)
+            item_name = get_formatted_item_name(ctx, Locations.HRUGIS_RACE_PB.location_id)
             manager.inject(0x2FEB, f"Perfect Ring Bonus: {item_name}")
 
         elif ctx.current_planet is Rac2Planet.Joba:
-            item_name = manager.get_formatted_item_name(Locations.JOBA_SHADY_SALESMAN.location_id)
+            item_name = get_formatted_item_name(ctx, Locations.JOBA_SHADY_SALESMAN.location_id)
             manager.inject(0x27BB, f"\x12 Buy {item_name} for %d bolts")
             manager.inject(0x27BC, f"You need %d bolts for {item_name}")
-            item_name = manager.get_formatted_item_name(Locations.JOBA_ARENA_BATTLE.location_id)
+            item_name = get_formatted_item_name(ctx, Locations.JOBA_ARENA_BATTLE.location_id)
             manager.inject(0x2F66, f"Battle for {item_name}")
             manager.inject(0x2F96, f"You have earned {item_name}")
-            item_name = manager.get_formatted_item_name(Locations.JOBA_ARENA_CAGE_MATCH.location_id)
+            item_name = get_formatted_item_name(ctx, Locations.JOBA_ARENA_CAGE_MATCH.location_id)
             manager.inject(0x2F67, f"Cage Match for {item_name}")
             manager.inject(0x2F97, f"You have earned {item_name}")
 
         elif ctx.current_planet is Rac2Planet.Todano:
-            item_name = manager.get_formatted_item_name(Locations.TODANO_STUART_ZURGO_TRADE.location_id)
+            item_name = get_formatted_item_name(ctx, Locations.TODANO_STUART_ZURGO_TRADE.location_id)
             manager.inject(0x27D3, f"You need the Qwark action figure for {item_name}")
             manager.inject(0x27D4, f"Trade Qwark action figure for {item_name}")
 
         elif ctx.current_planet is Rac2Planet.Aranos_Prison:
-            item_name = manager.get_formatted_item_name(Locations.ARANOS_PLUMBER.location_id)
+            item_name = get_formatted_item_name(ctx, Locations.ARANOS_PLUMBER.location_id)
             manager.inject(0x27D5, f"You need %d bolts for {item_name}")
             manager.inject(0x27D6, f"\x12 Buy {item_name} for %d bolts")
 
         elif ctx.current_planet is Rac2Planet.Gorn:
-            item_name = manager.get_formatted_item_name(Locations.GORN_DEFEAT_THUG_FLEET.location_id)
+            item_name = get_formatted_item_name(ctx, Locations.GORN_DEFEAT_THUG_FLEET.location_id)
             manager.inject(0x11FF, f"Received {item_name}")
-            item_name = manager.get_formatted_item_name(Locations.GORN_RACE_PB.location_id)
+            item_name = get_formatted_item_name(ctx, Locations.GORN_RACE_PB.location_id)
             manager.inject(0x2FF2, f"Perfect Ring Bonus: {item_name}")
 
         elif ctx.current_planet is Rac2Planet.Smolg:
-            item_name = manager.get_formatted_item_name(Locations.SMOLG_MUTANT_CRAB.location_id)
+            item_name = get_formatted_item_name(ctx, Locations.SMOLG_MUTANT_CRAB.location_id)
             manager.inject(0x27D7, f"You need %d bolts for {item_name}")
             manager.inject(0x27D8, f"\x12 Buy {item_name} for %d bolts")
 
         elif ctx.current_planet is Rac2Planet.Damosel:
-            item_name = manager.get_formatted_item_name(Locations.DAMOSEL_HYPNOTIST.location_id)
+            item_name = get_formatted_item_name(ctx, Locations.DAMOSEL_HYPNOTIST.location_id)
             manager.inject(0x27DA, f"You need %d bolts for {item_name}")
             manager.inject(0x27DB, f"\x12 Trade parts and %d bolts for {item_name}")
 
         elif ctx.current_planet is Rac2Planet.Grelbin:
-            item_name = manager.get_formatted_item_name(Locations.GRELBIN_MYSTIC_MORE_MOONSTONES.location_id)
+            item_name = get_formatted_item_name(ctx, Locations.GRELBIN_MYSTIC_MORE_MOONSTONES.location_id)
             manager.inject(0x27DE, f"You need 16 \x0CMoonstones\x08 for {item_name}")
             manager.inject(0x27DF, f"\x12 Trade 16 \x0CMoonstones\x08 for {item_name}")
     except TypeError:

--- a/ClientCheckLocations.py
+++ b/ClientCheckLocations.py
@@ -1,6 +1,7 @@
 from typing import Dict, TYPE_CHECKING
 
 from .Rac2Interface import PLANET_LIST_SIZE, INVENTORY_SIZE, NANOTECH_BOOST_MAX
+from .TextManager import get_formatted_item_name
 from .data import Planets, Locations, Items
 
 if TYPE_CHECKING:
@@ -157,9 +158,5 @@ async def handle_checked_location(ctx: 'Rac2Context'):
         location_name = [loc for loc in Planets.ALL_LOCATIONS if loc.location_id == location_id].pop().name
         ctx.game_interface.logger.info(f"Location checked: {location_name}")
 
-        net_item = ctx.locations_info[location_id]
-        if net_item.player != ctx.slot:
-            ctx.notification_manager.queue_notification(
-                f"Sent \x0C{ctx.item_names.lookup_in_slot(net_item.item, net_item.player)}\x08 \
-                to {ctx.player_names[net_item.player]}."
-            )
+        item_to_player_names = get_formatted_item_name(ctx, location_id, True)
+        ctx.notification_manager.queue_notification(f"Sent {item_to_player_names}")

--- a/ClientCheckLocations.py
+++ b/ClientCheckLocations.py
@@ -1,7 +1,7 @@
 from typing import Dict, TYPE_CHECKING
 
 from .Rac2Interface import PLANET_LIST_SIZE, INVENTORY_SIZE, NANOTECH_BOOST_MAX
-from .TextManager import get_formatted_item_name
+from .TextManager import get_rich_item_name
 from .data import Planets, Locations, Items
 
 if TYPE_CHECKING:
@@ -158,5 +158,7 @@ async def handle_checked_location(ctx: 'Rac2Context'):
         location_name = [loc for loc in Planets.ALL_LOCATIONS if loc.location_id == location_id].pop().name
         ctx.game_interface.logger.info(f"Location checked: {location_name}")
 
-        item_to_player_names = get_formatted_item_name(ctx, location_id, True)
-        ctx.notification_manager.queue_notification(f"Sent {item_to_player_names}")
+        net_item = ctx.locations_info.get(location_id, None)
+        if net_item is not None and net_item.player != ctx.slot:
+            item_to_player_names = get_rich_item_name(ctx, net_item, True)
+            ctx.notification_manager.queue_notification(f"Sent {item_to_player_names}")

--- a/ClientReceiveItems.py
+++ b/ClientReceiveItems.py
@@ -20,7 +20,7 @@ def show_item_reception_message(ctx: 'Rac2Context', item: NetworkItem, item_name
     :param qty: The amount obtained
     """
     if item_name is None:
-        item_name = ctx.item_names.lookup_in_slot(item.item, item.player)
+        item_name = ctx.item_names.lookup_in_slot(item.item, ctx.slot)
     if qty > 1:
         item_name += f" x{qty}"
     item_name = colorize_item_name(item_name, item.flags)

--- a/ClientReceiveItems.py
+++ b/ClientReceiveItems.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 from NetUtils import NetworkItem
-from . import Rac2World
+from . import Rac2World, ItemPool
 from .TextManager import colorize_item_name
 from .data import Items
 from .data.Items import EquipmentData, CoordData, ProgressiveUpgradeData
@@ -19,11 +19,15 @@ def show_item_reception_message(ctx: 'Rac2Context', item: NetworkItem, item_name
     :param item_name: The name to use for the item (if unspecified, it is obtained from the NetworkItem)
     :param qty: The amount obtained
     """
+    item_classification = item.flags
     if item_name is None:
         item_name = ctx.item_names.lookup_in_slot(item.item, ctx.slot)
+    if item.location == -2:
+        # For some reason, starting items don't have their classification flags set properly
+        item_classification = ItemPool.get_classification(item_name).as_flag()
     if qty > 1:
         item_name += f" x{qty}"
-    item_name = colorize_item_name(item_name, item.flags)
+    item_name = colorize_item_name(item_name, item_classification)
 
     if item.location == -2:
         # This is a starting item, mention it in the message

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from . import Rac2World
 
 
-def get_classification(_world: "Rac2World", item_name: str) -> ItemClassification:
+def get_classification(item_name: str) -> ItemClassification:
     item = Items.from_name(item_name)
     if item in Items.COORDS:
         return ItemClassification.progression

--- a/Rac2Interface.py
+++ b/Rac2Interface.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from time import sleep
 from logging import Logger
 from enum import Enum, IntEnum
-from typing import Optional, List
+from typing import Optional, List, Dict
 
 from .TextManager import wrap_text
 from .data import Items
@@ -212,6 +212,7 @@ class Rac2Interface:
     game_id_error: str = None
     game_rev_error: int = None
     current_game: Optional[str] = None
+    text_ids_cache: Dict[int, int] = {}
 
     def __init__(self, logger) -> None:
         self.logger = logger
@@ -507,26 +508,43 @@ class Rac2Interface:
     def nop_instruction(self, address: int):
         self.write_instruction(address, 0x0)
 
-    def get_text_offset_addr(self, index: int) -> Optional[int]:
+    def get_text_offset_addr(self, text_id: int) -> Optional[int]:
         text_address_table = self.get_segment_pointer_table().help_messages
+
+        # If text segment starts with "WAD", it means the game is currently performing a light reload
+        # (e.g. after a death) and writing over this data would most likely crash the game.
+        header = self.pcsx2_interface.read_int32(text_address_table)
+        if header & 0x00FFFFFF == 0x444157:  # "WAD"
+            return None
+
+        # Since the order of text IDs is always the same in the table for a given version of the game, we store the
+        # position of each text ID we encounter to avoid looping over that table ever again.
+        if text_id in self.text_ids_cache:
+            return text_address_table + self.text_ids_cache[text_id] * 0x10
+
+        # Perform a lookup on the text offsets table to know the address of the string referenced by the given text ID
+        # Cache all offsets in this table inside the dictionary to not have to perform that lookup next time.
         i = 0
         while True:
-            current_index = self.pcsx2_interface.read_int32(text_address_table + i * 0x10 + 0x4)
-            if current_index > 0x2000000:
+            current_text_id = self.pcsx2_interface.read_int32(text_address_table + i * 0x10 + 0x4)
+            self.text_ids_cache[current_text_id] = i
+            if current_text_id > 0x2000000:
                 return None
-            if current_index == index:
+            if current_text_id == text_id:
                 return text_address_table + i * 0x10
             i += 1
 
-    def get_text_address(self, index: int) -> Optional[int]:
-        offset_addr = self.get_text_offset_addr(index)
+    def get_text_address(self, text_id: int) -> Optional[int]:
+        offset_addr = self.get_text_offset_addr(text_id)
         if offset_addr:
             return self.pcsx2_interface.read_int32(offset_addr)
 
-    def set_text_address(self, index: int, addr: int):
-        offset_addr = self.get_text_offset_addr(index)
+    def set_text_address(self, text_id: int, addr: int) -> bool:
+        offset_addr = self.get_text_offset_addr(text_id)
         if offset_addr:
             self.pcsx2_interface.write_int32(offset_addr, addr)
+            return True
+        return False
 
     def get_segment_pointer_table(self) -> Optional[MemorySegmentTable]:
         if self.addresses is None:

--- a/Rac2Interface.py
+++ b/Rac2Interface.py
@@ -1,18 +1,17 @@
 import array
 import dataclasses
 import struct
-import textwrap
 from dataclasses import dataclass, field
 from time import sleep
 from logging import Logger
 from enum import Enum, IntEnum
 from typing import Optional, List
 
+from .TextManager import wrap_text
 from .data import Items
 from .data.RamAddresses import Addresses
 from .data.Items import ItemData, EquipmentData, CoordData, CollectableData
 from .pcsx2_interface.pine import Pine
-from . import Rac2World
 
 _SUPPORTED_VERSIONS = ["SCUS-97268"]
 
@@ -442,10 +441,8 @@ class Rac2Interface:
         ):
             return False
 
-        message = "\1".join(textwrap.wrap(message, width=35, replace_whitespace=False, break_long_words=False))
-
         try:
-            payload_message = message.encode() + b"\00"
+            payload_message = wrap_text(message, 25, 35).encode() + b"\00"
             message_address = self.addresses.planet[self.get_current_planet()].skill_point_text
 
             if not message_address:

--- a/TextManager.py
+++ b/TextManager.py
@@ -3,82 +3,111 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .Rac2Client import Rac2Context
 
+COLOR_WHITE = '\x08'
+COLOR_BLUE = '\x09'
+COLOR_GREEN = '\x0A'
+COLOR_VIOLET = '\x0B'
+COLOR_ORANGE = '\x0C'
+
+
+def colorize_item_name(item_name: str, item_flags: int):
+    # Take a color depending on item's usefulness
+    color = COLOR_GREEN  # Filler / Trap = Green
+    if item_flags & 0b001:
+        color = COLOR_ORANGE  # Progression = Orange
+    elif item_flags & 0b010:
+        color = COLOR_BLUE  # Useful = Blue
+    return f"{color}{item_name}{COLOR_WHITE}"
+
+
+def get_formatted_item_name(ctx: 'Rac2Context', location_id: int, player_name_after: bool = False):
+    net_item = ctx.locations_info.get(location_id, None)
+    if net_item is None:
+        return "???"
+    item_name = ctx.item_names.lookup_in_slot(net_item.item, net_item.player)
+    item_name = colorize_item_name(item_name, net_item.flags)
+
+    if ctx.slot == net_item.player:
+        # Item is ours, no need to specify player name
+        return item_name
+    else:
+        # Item belongs to someone else, give their name
+        player_name = ctx.player_names.get(net_item.player, "???")
+        if player_name_after:
+            return f"{item_name} to {player_name}"
+        return f"{player_name}'s {item_name}"
+
+
+def add_line_breaks(text: str, max_word_size: int, max_line_size: int) -> str:
+    """
+    Formats the given string with line breaks and ellipsis where relevant.
+
+    :param text: the input text
+    :param max_word_size: the max size of a word in bytes (if longer, it is truncated using "...")
+    :param max_line_size: the max size of a line in bytes (line breaks are placed to respect this rule)
+    """
+    words = [word if len(word) < max_word_size else f"{word}\xAD" for word in text.split(' ')]
+    lines = []
+    while len(words) > 0:
+        current_line = ""
+        while len(words) > 0:
+            if len(current_line) > 0:
+                # If adding that word would make the line go over the size limit, "commit" the line by breaking
+                # process next line
+                if len(current_line) + 1 + len(words[0]) > max_line_size:
+                    break
+                current_line += " "
+            current_line += words[0]
+            words = words[1:]
+        lines.append(current_line)
+        # Propagate color to next line if it wasn't white and there will be another line
+        if len(words) > 0:
+            for char in current_line[::-1]:
+                if 0x09 <= ord(char) <= 0x0f:
+                    words[0] = char + words[0]
+                    break
+
+    joining_str = '\x01'
+    # Pad lines with a few spaces if strings begin with a controller button icon
+    if 0x10 <= ord(lines[0][0]) <= 0x19:
+        joining_str += "    "
+    return joining_str.join(lines)
+
 
 class TextManager:
-    """
-    This dynamic text injector replaces the "Clank's Day at Insomniac" contiguous strings by others of our own,
-    and automatically re-route existing vanilla text by changing offsets to point on those new strings.
-    """
-    DYNAMIC_TEXT_BLOCK_SIZE = 0x893
-
     def __init__(self, ctx: 'Rac2Context'):
         self.ctx = ctx
-        self.base_addr = ctx.game_interface.get_text_address(0x3246)  # First "Clank's Day at Insomniac" string
-        self.addr = self.base_addr
+        self.injectable_chunks = []
 
-    def current_size(self):
-        return self.addr - self.base_addr
-
-    def get_formatted_item_name(self, location_id: int):
-        net_item = self.ctx.locations_info.get(location_id, None)
-        if net_item is None:
-            return "???"
-        item_name = self.ctx.item_names.lookup_in_slot(net_item.item, net_item.player)
-
-        # Take a color depending on item's usefulness
-        color = '\x0A'  # Filler / Trap = Green
-        if net_item.flags & 0b001:
-            color = '\x0C'  # Progression = Orange
-        elif net_item.flags & 0b010:
-            color = '\x09'  # Useful = Blue
-
-        # Item is ours, no need to specify player name
-        if self.ctx.slot == net_item.player:
-            return f"{color}{item_name}\x08"
-        # Item belongs to someone else, give their name
-        player_name = self.ctx.player_names.get(net_item.player, "???")
-        return f"{color}{player_name}'s {item_name}\x08"
-
-    @staticmethod
-    def format_text(text: str, max_word_size: int, max_line_size: int) -> str:
-        words = [word if len(word) < max_word_size else f"{word}\xAD" for word in text.split(' ')]
-        lines = []
-        while len(words) > 0:
-            current_line = ""
-            while len(words) > 0:
-                if len(current_line) > 0:
-                    # If adding that word would make the line go over the size limit, "commit" the line by breaking
-                    # process next line
-                    if len(current_line) + 1 + len(words[0]) > max_line_size:
-                        break
-                    current_line += " "
-                current_line += words[0]
-                words = words[1:]
-            lines.append(current_line)
-            # Propagate color to next line if it wasn't white and there will be another line
-            if len(words) > 0:
-                for char in current_line[::-1]:
-                    if 0x09 <= ord(char) <= 0x0f:
-                        words[0] = char + words[0]
-                        break
-
-        joining_str = '\x01'
-        # Pad lines with a few spaces if strings begin with a controller button icon
-        if 0x10 <= ord(lines[0][0]) <= 0x19:
-            joining_str += "    "
-        return joining_str.join(lines)
+        clanks_day_at_insomniac_chunk = ctx.game_interface.get_text_address(0x3246)
+        self.injectable_chunks.append([clanks_day_at_insomniac_chunk, clanks_day_at_insomniac_chunk + 0x893])
+        insomniac_museum_chunk = ctx.game_interface.get_text_address(0x1BAD)
+        self.injectable_chunks.append([insomniac_museum_chunk, insomniac_museum_chunk + 0x18DC])
 
     def inject(self, vanilla_text_id: int, text: str):
-        text_bytes = self.format_text(text, 32, 40).encode() + b'\x00'
-        if self.current_size() + len(text_bytes) > TextManager.DYNAMIC_TEXT_BLOCK_SIZE:
-            # Failsafe, but it should never happen if proper limits are set in `get_descriptive_item_name`
-            size_left = TextManager.DYNAMIC_TEXT_BLOCK_SIZE - self.current_size() - 1
-            text_bytes = text_bytes[:size_left] + b'\x00'
-        self.ctx.game_interface.pcsx2_interface.write_bytes(self.addr, text_bytes)
-        self.ctx.game_interface.set_text_address(vanilla_text_id, self.addr)
-        self.addr += len(text_bytes)
+        """
+        Replace a vanilla string by injecting the given text in some unused space, and re-routing the text ID on this
+        new address. This is needed when replacement string have a chance of exceeding original string size, otherwise
+        prefer using `replace`.
+        """
+        text_bytes = add_line_breaks(text, 32, 40).encode() + b'\x00'
+
+        for chunk in self.injectable_chunks:
+            remaining_bytes = chunk[1] - chunk[0]
+            if len(text_bytes) <= remaining_bytes:
+                # We found a chunk with enough room to inject the string, do it
+                self.ctx.game_interface.pcsx2_interface.write_bytes(chunk[0], text_bytes)
+                self.ctx.game_interface.set_text_address(vanilla_text_id, chunk[0])
+                chunk[0] += len(text_bytes)
+                return
+
+        self.ctx.game_interface.logger.error(f"Not enough space to inject game text, please report this issue!")
 
     def replace(self, vanilla_text_id: int, text: str):
+        """
+        Replaces a vanilla string by simply overwriting the vanilla string contents. If not used carefully, this can
+        overlap the following strings, so use this carefully or use `inject` instead if you have any doubt.
+        """
         addr = self.ctx.game_interface.get_text_address(vanilla_text_id)
         if addr:
             text_bytes = text.encode() + b'\x00'

--- a/TextManager.py
+++ b/TextManager.py
@@ -106,9 +106,9 @@ class TextManager:
             remaining_bytes = chunk[1] - chunk[0]
             if len(text_bytes) <= remaining_bytes:
                 # We found a chunk with enough room to inject the string, do it
-                self.ctx.game_interface.pcsx2_interface.write_bytes(chunk[0], text_bytes)
-                self.ctx.game_interface.set_text_address(vanilla_text_id, chunk[0])
-                chunk[0] += len(text_bytes)
+                if self.ctx.game_interface.set_text_address(vanilla_text_id, chunk[0]):
+                    self.ctx.game_interface.pcsx2_interface.write_bytes(chunk[0], text_bytes)
+                    chunk[0] += len(text_bytes)
                 return
 
         self.ctx.game_interface.logger.error(f"Not enough space to inject game text, please report this issue!")

--- a/__init__.py
+++ b/__init__.py
@@ -85,7 +85,7 @@ class Rac2World(World):
     def create_item(self, name: str, override: Optional[ItemClassification] = None) -> "Item":
         if override:
             return Rac2Item(name, override, self.item_name_to_id[name], self.player)
-        return Rac2Item(name, ItemPool.get_classification(self, name), self.item_name_to_id[name], self.player)
+        return Rac2Item(name, ItemPool.get_classification(name), self.item_name_to_id[name], self.player)
 
     def create_event(self, name: str) -> "Item":
         return Rac2Item(name, ItemClassification.progression, None, self.player)


### PR DESCRIPTION
This PR does quite a lot of small fixes / improvements regarding text handling:
- unified all text handling to use the same wrapping / colouring functions (HUD messages like "Received X" and "Sent X" were using other methods)
- simplified the handling of "received items messages" by centralizing all of it in one function
- replaced "Received X" by "Found X" when the player finds an item for themselves
- added offset caching to lighten the PINE load induced by text lookup
- fixed some cosmetic issues regarding TextManager (color propagation between lines was done incorrectly, etc...)
- fixed a rare crash that could occur when `replace_text` was writing stuff during a "light reload" (e.g. during a respawn)
- added a bunch of documentation & comments on text-related functions

This was tested during a private async, and this game was the reason I found the small bugs that got fixed in the first place.