### PR TITLE
Hotfix small issues for 0.5.0

### DIFF
--- a/Callbacks.py
+++ b/Callbacks.py
@@ -112,7 +112,7 @@ def replace_text(ctx: 'Rac2Context', ap_connected: bool):
         elif ctx.current_planet is Rac2Planet.Todano:
             item_name = get_rich_item_name_from_location(ctx, Locations.TODANO_STUART_ZURGO_TRADE.location_id)
             manager.inject(0x27D3, f"You need the Qwark action figure for {item_name}")
-            manager.inject(0x27D4, f"Trade Qwark action figure for {item_name}")
+            manager.inject(0x27D4, f"\x12 Trade Qwark action figure for {item_name}")
 
         elif ctx.current_planet is Rac2Planet.Aranos_Prison:
             item_name = get_rich_item_name_from_location(ctx, Locations.ARANOS_PLUMBER.location_id)

--- a/ClientReceiveItems.py
+++ b/ClientReceiveItems.py
@@ -22,7 +22,7 @@ def show_item_reception_message(ctx: 'Rac2Context', item: NetworkItem, item_name
     item_classification = item.flags
     if item_name is None:
         item_name = ctx.item_names.lookup_in_slot(item.item, ctx.slot)
-    if item.location == -2:
+    if item.location < 0:
         # For some reason, starting items don't have their classification flags set properly
         item_classification = ItemPool.get_classification(item_name).as_flag()
     if qty > 1:

--- a/Rac2Options.py
+++ b/Rac2Options.py
@@ -63,7 +63,7 @@ class FreeChallengeSelection(Toggle):
 class NanotechExperienceMultiplier(Range):
     """A multiplier applied to experience gained for Nanotech levels, in percent."""
     display_name = "Nanotech XP Multiplier"
-    range_start = 10
+    range_start = 20
     range_end = 400
     default = 100
 
@@ -71,7 +71,7 @@ class NanotechExperienceMultiplier(Range):
 class WeaponExperienceMultiplier(Range):
     """A multiplier applied to experience gained for weapon levels, in percent."""
     display_name = "Weapon XP Multiplier"
-    range_start = 10
+    range_start = 20
     range_end = 400
     default = 100
 


### PR DESCRIPTION
This PR fixes three minor issues for 0.5.0:
- Fixed generation crashing when having too small value for `weapon_xp_multiplier` option
- Fixed Qwark Statue trade message missing the "triangle button" character since the refactor
- Fixed cheated items (obtained through `!getitem`) not having the proper classification color, for the same reasons as starting items 