### PR TITLE
Fix text ID caching to prevent any bad reads/writes

### DIFF
--- a/Rac2Interface.py
+++ b/Rac2Interface.py
@@ -520,7 +520,12 @@ class Rac2Interface:
         # Since the order of text IDs is always the same in the table for a given version of the game, we store the
         # position of each text ID we encounter to avoid looping over that table ever again.
         if text_id in self.text_ids_cache:
-            return text_address_table + self.text_ids_cache[text_id] * 0x10
+            offset_addr = text_address_table + self.text_ids_cache[text_id] * 0x10
+            found_text_id = self.pcsx2_interface.read_int32(offset_addr + 0x4)
+            if found_text_id == text_id:
+                return offset_addr
+            # When changing planets, offsets can slightly shift for some reason: invalidate the cache
+            self.text_ids_cache.clear()
 
         # Perform a lookup on the text offsets table to know the address of the string referenced by the given text ID
         # Cache all offsets in this table inside the dictionary to not have to perform that lookup next time.


### PR DESCRIPTION
Text ID caching was introduced in last version to reduce the load on PINE requests related to text.
When finding an info in the text ID / text offsets matching table, it stores where that text ID was found relative to the start of that table to avoid having to loop over that table, saving thousands of PINE requests per second in the best cases.

An unpredicted issue emerged after some testing: the offsets sometimes slightly shift for some reason when changing planets, which led to read / writes in bad places. This can potentially lead to crash-inducing mistakes, and this is what this PR aims to fix.

The goal here was to keep most advantages of text ID caching while providing a minimalistic solution to avoid any kind of issue it could induce. The solution found is to **double check the text ID pointed by the cached address**: 
- this costs a single PINE request to check if text ID matches with the one we expect
- if it does match, it is trustable and we can use this address like we used to
- if it does not match, it means a shift happened (bad planet change occured) and we invalidate the cache

This was tested with extensive logging in the client in a solo seed and it kicked in more often I would have expected. This means many "silent" errors were potentially happening, while only a fraction of those lead to actual crashes / noticeable errors.