### PR TITLE
Fixed Joba cage matches freezing the game on start

### DIFF
--- a/Container.py
+++ b/Container.py
@@ -624,7 +624,7 @@ def patch_free_challenge_selection(patch: Rac2ProcedurePatch, addresses: IsoAddr
     address = addresses.MAKTAR_ARENA_MENU_FUNC
     patch.write_token(APTokenTypes.WRITE, address + 0xDC, NOP)  # Enable pressing right
     patch.write_token(APTokenTypes.WRITE, address + 0x204, NOP)  # Enable pressing left
-    patch.write_token(APTokenTypes.WRITE, address + 0x348, NOP)  # Enable starting a challenge without requirements
+    patch.write_token(APTokenTypes.WRITE, address + 0x348, NOP * 2)  # Enable starting a challenge without requirements
     patch.write_token(APTokenTypes.WRITE, addresses.MAKTAR_ARENA_DISPLAY_PREV_FUNC + 0x290, NOP)  # Display "previous"
     patch.write_token(APTokenTypes.WRITE, addresses.MAKTAR_ARENA_DISPLAY_NEXT_FUNC + 0x324, NOP)  # Display "next"
 

--- a/Container.py
+++ b/Container.py
@@ -632,7 +632,7 @@ def patch_free_challenge_selection(patch: Rac2ProcedurePatch, addresses: IsoAddr
     address = addresses.JOBA_ARENA_MENU_FUNC
     patch.write_token(APTokenTypes.WRITE, address + 0xDC, NOP)  # Enable pressing right
     patch.write_token(APTokenTypes.WRITE, address + 0x1CC, NOP)  # Enable pressing left
-    patch.write_token(APTokenTypes.WRITE, address + 0x2F0, NOP)  # Enable starting a challenge without requirements
+    patch.write_token(APTokenTypes.WRITE, address + 0x2F0, NOP * 2)  # Enable starting a challenge without requirements
     patch.write_token(APTokenTypes.WRITE, addresses.JOBA_ARENA_DISPLAY_PREV_FUNC + 0x288, NOP)  # Display "previous"
     patch.write_token(APTokenTypes.WRITE, addresses.JOBA_ARENA_DISPLAY_NEXT_FUNC + 0x364, NOP)  # Display "next"
 


### PR DESCRIPTION
This PR fixes the game freeze encountered by people playing with the `free_challenge_selection` option when starting a cage match in Joba arena.

This was caused by a `BEQL` instruction being NOP'ed out without noping the instruction right after (in the branch delay slot).
TIL that all branch opcodes ending with an "L" mean "Likely" and in that case, the branch delay slot instruction is **NOT** executed if the branch does not occur.
In our case, we were removing the branch, so instead of having a delay slot instruction that should never occur, it was always occuring because it was not a branch delay slot instruction anymore.