### PR TITLE
Clean up Tabora wrench upgrade flag check

### DIFF
--- a/Container.py
+++ b/Container.py
@@ -461,9 +461,10 @@ def generate_patch(world: "Rac2World", patch: Rac2ProcedurePatch, instruction=No
     # Have Wrench pickup check a custom flag to determine if it has been checked.
     address = addresses.TABORA_CONTROLLER_FUNC
     upper_half, lower_half = MIPS.get_address_halves(ram.tabora_wrench_cutscene_flag)
-    patch.write_token(APTokenTypes.WRITE, address + 0x194, upper_half + bytes([0x03, 0x3C]))  # lui v1,...
-    patch.write_token(APTokenTypes.WRITE, address + 0x198, lower_half + bytes([0x62, 0x90]))  # lbu v0,...(v1)
-    patch.write_token(APTokenTypes.WRITE, address + 0x19C, NOP * 16)
+    patch.write_token(APTokenTypes.WRITE, address + 0x1D4, bytes([
+        *upper_half, 0x03, 0x3C,  # lui v1,...
+        *lower_half, 0x62, 0x90,  # lbu v0,...(v1)
+    ]))
 
     # Replace the code that upgrades wrench and displays a message by code that just sets a custom flag.
     # Also removes the wrench skin change + HUD message on pickup.


### PR DESCRIPTION
Currently, the check that tests if the custom flag for Tabora wrench upgrade cutscene has been set is a bit rough and replaces 2 instructions, while noping the 16 next instructions.
The problem is that among those instructions are some that set values in storage registries (`sX`) which are used *after* this check, and registries are now uninitialized and could potentially contain random stuff.

This PR makes the whole procedure more minimalistic and less impactful on the rest of the procedure, which might solve the underlying cause of https://github.com/evilwb/APRac2/issues/45