### PR TITLE
Added bolt packs as filler items

### DIFF
--- a/ClientReceiveItems.py
+++ b/ClientReceiveItems.py
@@ -87,7 +87,7 @@ def handle_received_collectables(ctx: 'Rac2Context', current_items: dict[str, in
         diff = received_amount - in_game_amount
         if diff > 0 and in_game_amount < item.max_capacity:
             new_amount = min(received_amount, item.max_capacity)
-            ctx.game_interface.give_collectable_to_player(item, new_amount)
+            ctx.game_interface.give_collectable_to_player(item, new_amount, in_game_amount)
             show_item_reception_message(ctx, received_collectables[-1], None, diff)
 
 

--- a/__init__.py
+++ b/__init__.py
@@ -82,7 +82,7 @@ class Rac2World(World):
     prefilled_item_map: Dict[str, str] = {}  # Dict of location name to item name
 
     def get_filler_item_name(self) -> str:
-        return Items.PLATINUM_BOLT.name
+        return Items.BOLT_PACK.name
 
     def create_regions(self) -> None:
         create_regions(self)
@@ -112,9 +112,9 @@ class Rac2World(World):
         # add platinum bolts in whatever slots we have left
         remain = (len(Planets.ALL_LOCATIONS) - 1) - len(items_to_add)
         assert remain >= 0, "There are more items than locations. This is not supported."
-        print(f"Not enough items to fill all locations. Adding {remain} Platinum Bolt(s) to the item pool")
+        print(f"Not enough items to fill all locations. Adding {remain} filler items to the item pool")
         for _ in range(remain):
-            items_to_add.append(self.create_item(Items.PLATINUM_BOLT.name, ItemClassification.filler))
+            items_to_add.append(self.create_item(Items.BOLT_PACK.name, ItemClassification.filler))
 
         self.multiworld.itempool += items_to_add
 

--- a/data/Items.py
+++ b/data/Items.py
@@ -102,13 +102,14 @@ YEEDIL_COORDS = CoordData(220, "Yeedil Coordinates", 20)
 
 @dataclass
 class CollectableData(ItemData):
-    max_capacity: int
+    max_capacity: int = 0x7F
 
 
 # Collectables
 PLATINUM_BOLT = CollectableData(301, "Platinum Bolt", 40)
 NANOTECH_BOOST = CollectableData(302, "Nanotech Boost", 10)
 HYPNOMATIC_PART = CollectableData(303, "Hypnomatic Part", 3)
+BOLT_PACK = CollectableData(304, "Bolt Pack")
 
 
 @dataclass
@@ -207,6 +208,7 @@ COLLECTABLES: Sequence[CollectableData] = [
     PLATINUM_BOLT,
     NANOTECH_BOOST,
     HYPNOMATIC_PART,
+    BOLT_PACK,
 ]
 UPGRADES: Sequence[ProgressiveUpgradeData] = [
     WRENCH_UPGRADE,

--- a/data/RamAddresses.py
+++ b/data/RamAddresses.py
@@ -72,6 +72,7 @@ class Addresses:
             self.tabora_wrench_cutscene_flag: int = self.feltzin_kill_count_table + 0x1
             self.aranos_wrench_cutscene_flag: int = self.feltzin_kill_count_table + 0x2
             self.custom_text_notification_trigger: int = self.feltzin_kill_count_table + 0x3
+            self.bolt_pack_count: int = self.feltzin_kill_count_table + 0x4
 
             # Pause state is at 0x1A8F00 on all planets except for Oozla where it's at 0x1A8F40.
             self.pause_state: int = 0x1A8F00


### PR DESCRIPTION
This PR adds a new "Bolt Pack" item classified as filler which gives 20% of currently owned bolts (but never less than 10k) when obtained. This allows the item to slightly scale in the later parts of the game where giving 10k bolts would be absolutely meaningless.