### PR TITLE
Add item & location groups

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -78,6 +78,8 @@ class Rac2World(World):
     topology_present = True
     item_name_to_id = {item.name: item.item_id for item in Items.ALL}
     location_name_to_id = {location.name: location.location_id for location in Planets.ALL_LOCATIONS if location.location_id}
+    item_name_groups = Items.get_item_groups()
+    location_name_groups = Planets.get_location_groups()
     settings: Rac2Settings
     starting_planet: Optional[PlanetData] = None
     starting_weapons: list[EquipmentData] = []

--- a/data/Items.py
+++ b/data/Items.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from abc import ABC
 
-from typing import Callable, TYPE_CHECKING, Sequence, Optional
+from typing import Callable, TYPE_CHECKING, Sequence, Optional, Dict, Set
 
 if TYPE_CHECKING:
     from ..Rac2Interface import Rac2Interface
@@ -508,3 +508,12 @@ def coord_for_planet(number: int) -> CoordData:
     assert len(matching) > 0, f"No coords for planet number '{number}'."
     assert len(matching) < 2, f"Multiple coords for planet number '{number}'. Please report."
     return matching[0]
+
+
+def get_item_groups() -> Dict[str, Set[str]]:
+    groups: Dict[str, Set[str]] = {
+        "Weapons": {w.name for w in WEAPONS},
+        "Coordinates": {c.name for c in COORDS},
+        "Equipment": {e.name for e in EQUIPMENT},
+    }
+    return groups

--- a/data/Planets.py
+++ b/data/Planets.py
@@ -1,3 +1,5 @@
+from typing import Set
+
 from .Locations import *
 
 
@@ -207,6 +209,42 @@ ALL_LOCATIONS: Sequence[LocationData] = [
     for locations in [planet.locations for planet in LOGIC_PLANETS]
     for location in locations
 ]
+
+
+def get_location_groups() -> Dict[str, Set[str]]:
+    groups: Dict[str, Set[str]] = {}
+    for planet in LOGIC_PLANETS:
+        groups[planet.name] = {loc.name for loc in planet.locations}
+    groups.update({
+        "Spaceship": {
+            *groups[FELTZIN_SYSTEM.name],
+            *groups[HRUGIS_CLOUD.name],
+            *groups[GORN.name]
+        },
+        "Hoverbike": {
+            BARLOW_HOVERBIKE_RACE_TRANSMISSION.name,
+            BARLOW_HOVERBIKE_RACE_PB.name,
+            JOBA_FIRST_HOVERBIKE_RACE.name,
+            JOBA_HOVERBIKE_RACE_SHORTCUT_NT.name,
+        },
+        "Giant Clank": {
+            DOBBO_DEFEAT_THUG_LEADER.name,
+            DAMOSEL_DEFEAT_MOTHERSHIP.name,
+        },
+        "Arena": {
+            MAKTAR_ARENA_CHALLENGE.name,
+            JOBA_ARENA_BATTLE.name,
+            JOBA_ARENA_CAGE_MATCH.name,
+        },
+        "Tanky Bosses": {
+            SNIVELAK_RESCUE_ANGELA.name,
+            OOZLA_SWAMP_MONSTER_II.name,
+            DOBBO_DEFEAT_THUG_LEADER.name,
+            DAMOSEL_DEFEAT_MOTHERSHIP.name,
+        },
+    })
+
+    return groups
 
 
 class SpaceshipSystemTextInfo(NamedTuple):


### PR DESCRIPTION
This PR adds:
- item groups to facilitate hinting ("Weapons", "Equipment" and "Coordinates")
- location groups to facilitate exclusion
  - one for each planet
  - a few thematic ones ("Spaceship", "Hoverbike", "Arena", "Giant Clank" and "Tanky Bosses") 