### PR TITLE
Fix weapon experience multiplier option range

### DIFF
--- a/Rac2Options.py
+++ b/Rac2Options.py
@@ -90,7 +90,7 @@ class NanotechExperienceMultiplier(Range):
 class WeaponExperienceMultiplier(Range):
     """A multiplier applied to experience gained for weapon levels, in percent."""
     display_name = "Weapon XP Multiplier"
-    range_start = 20
+    range_start = 30
     range_end = 600
     default = 100
 

--- a/Simplified Ratchet & Clank 2.yaml
+++ b/Simplified Ratchet & Clank 2.yaml
@@ -84,7 +84,7 @@ Ratchet & Clank 2:
   # A multiplier applied to experience gained for Nanotech levels, in percent.
   #
   # You can define additional values between the minimum and maximum values.
-  # Minimum value is 30
+  # Minimum value is 20
   # Maximum value is 600
   nanotech_xp_multiplier: 100
 

--- a/Simplified Ratchet & Clank 2.yaml
+++ b/Simplified Ratchet & Clank 2.yaml
@@ -84,15 +84,15 @@ Ratchet & Clank 2:
   # A multiplier applied to experience gained for Nanotech levels, in percent.
   #
   # You can define additional values between the minimum and maximum values.
-  # Minimum value is 10
-  # Maximum value is 400
+  # Minimum value is 30
+  # Maximum value is 600
   nanotech_xp_multiplier: 100
 
   # A multiplier applied to experience gained for weapon levels, in percent.
   #
   # You can define additional values between the minimum and maximum values.
-  # Minimum value is 10
-  # Maximum value is 400
+  # Minimum value is 30
+  # Maximum value is 600
   weapon_xp_multiplier: 100
 
   # In the vanilla game, only the first challenge and the race challenge completed perfectly give an item as a


### PR DESCRIPTION
This PR increases the `weapon_xp_multiplier` lower bound from 20% to 30% since using any value lower than 30% was raising an exception since the introduction of Mega weapons in the xp table.