### PR TITLE
Fix vendor refresh issues for remote items

### DIFF
--- a/Callbacks.py
+++ b/Callbacks.py
@@ -235,14 +235,12 @@ def process_vendor_text(manager: TextManager, ctx: "Rac2Context") -> None:
     if vendor.mode is Vendor.Mode.MEGACORP:
         for location, weapon in zip(Locations.MEGACORP_VENDOR_LOCATIONS, Items.MEGACORP_VENDOR_WEAPONS):
             text_id = ctx.game_interface.pcsx2_interface.read_int32(equipment_data + weapon.offset * 0xE0 + 0x08)
-            location_info = ctx.locations_info[location.location_id]
-            item_name = ctx.item_names.lookup_in_slot(location_info.item, location_info.player)
+            item_name = get_rich_item_name_from_location(ctx, location.location_id)
             manager.inject(text_id, item_name)
     elif vendor.mode is Vendor.Mode.GADGETRON:
         for location, weapon in zip(Locations.GADGETRON_VENDOR_LOCATIONS, Items.GADGETRON_VENDOR_WEAPONS):
             text_id = ctx.game_interface.pcsx2_interface.read_int32(equipment_data + weapon.offset * 0xE0 + 0x08)
-            location_info = ctx.locations_info[location.location_id]
-            item_name = ctx.item_names.lookup_in_slot(location_info.item, location_info.player)
+            item_name = get_rich_item_name_from_location(ctx, location.location_id)
             manager.inject(text_id, item_name)
     else:
         locations: list[LocationData] = list(Locations.MEGACORP_VENDOR_LOCATIONS) + list(Locations.GADGETRON_VENDOR_LOCATIONS)

--- a/ClientReceiveItems.py
+++ b/ClientReceiveItems.py
@@ -56,12 +56,10 @@ async def handle_received_items(ctx: 'Rac2Context', current_items: dict[str, int
         if isinstance(item, EquipmentData) and current_items[item.name] == 0:
             ctx.game_interface.give_equipment_to_player(item)
             show_item_reception_message(ctx, network_item)
-            ctx.game_interface.vendor.refresh(ctx)
 
         if isinstance(item, CoordData) and current_items[item.name] == 0:
             ctx.game_interface.unlock_planet(item.planet_number)
             show_item_reception_message(ctx, network_item)
-            ctx.game_interface.vendor.refresh(ctx)
 
         if isinstance(item, ProgressiveUpgradeData):
             current_level = item.get_level_func(ctx.game_interface)
@@ -72,7 +70,6 @@ async def handle_received_items(ctx: 'Rac2Context', current_items: dict[str, int
                 item.set_level_func(ctx.game_interface, new_level)
             if current_level < new_level:
                 show_item_reception_message(ctx, network_item, item.progressive_names[new_level - 1])
-                ctx.game_interface.vendor.refresh(ctx)
 
     handle_received_collectables(ctx, current_items)
     resync_problem_items(ctx)
@@ -92,7 +89,6 @@ def handle_received_collectables(ctx: 'Rac2Context', current_items: dict[str, in
             new_amount = min(received_amount, item.max_capacity)
             ctx.game_interface.give_collectable_to_player(item, new_amount, in_game_amount)
             show_item_reception_message(ctx, received_collectables[-1], None, diff)
-            ctx.game_interface.vendor.refresh(ctx)
 
 
 def resync_problem_items(ctx: 'Rac2Context'):

--- a/data/Locations.py
+++ b/data/Locations.py
@@ -11,6 +11,7 @@ class LocationData(NamedTuple):
     access_rule: Optional[Callable[[CollectionState, int], bool]] = None
     checked_flag_address: Optional[Callable[["Addresses"], int]] = None
     enable_if: Optional[Callable[[Dict[str, Any]], bool]] = None
+    is_vendor: bool = False
 
 
 """ Oozla """
@@ -430,104 +431,124 @@ YEEDIL_TRACTOR_PILLAR_PB = LocationData(
 OOZLA_VENDOR_WEAPON_1 = LocationData(
     300, "Oozla: Megacorp Vendor - New Weapon 1",
     checked_flag_address=lambda ram: ram.secondary_inventory + Items.CHOPPER.offset,
-    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"]
+    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"],
+    is_vendor=True
 )
 OOZLA_VENDOR_WEAPON_2 = LocationData(
     301, "Oozla: Megacorp Vendor - New Weapon 2",
     checked_flag_address=lambda ram: ram.secondary_inventory + Items.BLITZ_GUN.offset,
-    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"]
+    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"],
+    is_vendor=True
 )
 ENDAKO_VENDOR_WEAPON_1 = LocationData(
     302, "Endako: Megacorp Vendor - New Weapon 1",
     checked_flag_address=lambda ram: ram.secondary_inventory + Items.PULSE_RIFLE.offset,
-    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"]
+    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"],
+    is_vendor=True
 )
 ENDAKO_VENDOR_WEAPON_2 = LocationData(
     303, "Endako: Megacorp Vendor - New Weapon 2",
     checked_flag_address=lambda ram: ram.secondary_inventory + Items.MINITURRET_GLOVE.offset,
-    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"]
+    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"],
+    is_vendor=True
 )
 BARLOW_VENDOR_WEAPON = LocationData(
     304, "Barlow: Megacorp Vendor - New Weapon",
     checked_flag_address=lambda ram: ram.secondary_inventory + Items.SEEKER_GUN.offset,
-    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"]
+    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"],
+    is_vendor=True
 )
 NOTAK_VENDOR_WEAPON = LocationData(
     305, "Notak: Megacorp Vendor - New Weapon",
     checked_flag_address=lambda ram: ram.secondary_inventory + Items.SYNTHENOID.offset,
-    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"]
+    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"],
+    is_vendor=True
 )
 TABORA_VENDOR_WEAPON_1 = LocationData(
     306, "Tabora: Megacorp Vendor - New Weapon 1",
     checked_flag_address=lambda ram: ram.secondary_inventory + Items.LAVA_GUN.offset,
-    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"]
+    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"],
+    is_vendor=True
 )
 TABORA_VENDOR_WEAPON_2 = LocationData(
     307, "Tabora: Megacorp Vendor - New Weapon 2",
     checked_flag_address=lambda ram: ram.secondary_inventory + Items.BOUNCER.offset,
-    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"]
+    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"],
+    is_vendor=True
 )
 DOBBO_VENDOR_WEAPON = LocationData(
     308, "Dobbo: Megacorp Vendor - New Weapon",
     checked_flag_address=lambda ram: ram.secondary_inventory + Items.MINIROCKET_TUBE.offset,
-    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"]
+    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"],
+    is_vendor=True
 )
 JOBA_VENDOR_WEAPON_1 = LocationData(
     309, "Joba: Megacorp Vendor - New Weapon 1",
     checked_flag_address=lambda ram: ram.secondary_inventory + Items.SPIDERBOT_GLOVE.offset,
-    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"]
+    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"],
+    is_vendor=True
 )
 JOBA_VENDOR_WEAPON_2 = LocationData(
     310, "Joba: Megacorp Vendor - New Weapon 2",
     checked_flag_address=lambda ram: ram.secondary_inventory + Items.PLASMA_COIL.offset,
-    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"]
+    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"],
+    is_vendor=True
 )
 TODANO_VENDOR_WEAPON = LocationData(
     311, "Todano: Megacorp Vendor - New Weapon",
     checked_flag_address=lambda ram: ram.secondary_inventory + Items.HOVERBOMB_GUN.offset,
-    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"]
+    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"],
+    is_vendor=True
 )
 ARANOS_VENDOR_WEAPON_1 = LocationData(
     312, "Aranos Prison: Megacorp Vendor - New Weapon 1",
     checked_flag_address=lambda ram: ram.secondary_inventory + Items.SHIELD_CHARGER.offset,
-    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"]
+    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"],
+    is_vendor=True
 )
 ARANOS_VENDOR_WEAPON_2 = LocationData(
     313, "Aranos Prison: Megacorp Vendor - New Weapon 2",
     checked_flag_address=lambda ram: ram.secondary_inventory + Items.ZODIAC.offset,
-    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"]
+    enable_if=lambda options_dict: options_dict["randomize_megacorp_vendor"],
+    is_vendor=True
 )
 
 """ Gadgetron Vendor """
 BARLOW_GADGETRON_1 = LocationData(
     314, "Barlow: Gadgetron Vendor - Weapon 1",
     checked_flag_address=lambda ram: ram.secondary_inventory + Items.BOMB_GLOVE.offset,
-    enable_if=lambda options_dict: options_dict["randomize_gadgetron_vendor"]
+    enable_if=lambda options_dict: options_dict["randomize_gadgetron_vendor"],
+    is_vendor=True
 )
 BARLOW_GADGETRON_2 = LocationData(
     315, "Barlow: Gadgetron Vendor - Weapon 2",
     checked_flag_address=lambda ram: ram.secondary_inventory + Items.VISIBOMB_GUN.offset,
-    enable_if=lambda options_dict: options_dict["randomize_gadgetron_vendor"]
+    enable_if=lambda options_dict: options_dict["randomize_gadgetron_vendor"],
+    is_vendor=True
 )
 BARLOW_GADGETRON_3 = LocationData(
     316, "Barlow: Gadgetron Vendor - Weapon 3",
     checked_flag_address=lambda ram: ram.secondary_inventory + Items.TESLA_CLAW.offset,
-    enable_if=lambda options_dict: options_dict["randomize_gadgetron_vendor"]
+    enable_if=lambda options_dict: options_dict["randomize_gadgetron_vendor"],
+    is_vendor=True
 )
 BARLOW_GADGETRON_4 = LocationData(
     317, "Barlow: Gadgetron Vendor - Weapon 4",
     checked_flag_address=lambda ram: ram.secondary_inventory + Items.DECOY_GLOVE.offset,
-    enable_if=lambda options_dict: options_dict["randomize_gadgetron_vendor"]
+    enable_if=lambda options_dict: options_dict["randomize_gadgetron_vendor"],
+    is_vendor=True
 )
 BARLOW_GADGETRON_5 = LocationData(
     318, "Barlow: Gadgetron Vendor - Weapon 5",
     checked_flag_address=lambda ram: ram.secondary_inventory + Items.RYNO_II.offset,
-    enable_if=lambda options_dict: options_dict["randomize_gadgetron_vendor"]
+    enable_if=lambda options_dict: options_dict["randomize_gadgetron_vendor"],
+    is_vendor=True
 )
 BARLOW_GADGETRON_6 = LocationData(
     319, "Barlow: Gadgetron Vendor - Weapon 6",
     checked_flag_address=lambda ram: ram.secondary_inventory + Items.WALLOPER.offset,
-    enable_if=lambda options_dict: options_dict["randomize_gadgetron_vendor"]
+    enable_if=lambda options_dict: options_dict["randomize_gadgetron_vendor"],
+    is_vendor=True
 )
 
 # Keep in correct order


### PR DESCRIPTION
This PR solves two issues:
- https://github.com/evilwb/APRac2/issues/70

The main issue was that vendor got force-refreshed when receiving any new item, meaning it didn't get refreshed when an item was sent to another player. The changes in this PR changes when refresh is called: vendors are now only refreshed when a new vendor location is checked. 

This is accomplished by adding a temporary list which contains recently bought locations, which is combined with context checked locations history to have a full list of checked locations without having to wait for server to respond (since we know for sure the location was bought anyway).

---

- https://github.com/evilwb/APRac2/issues/69

Here is what it looks like for another player's item:

![image](https://github.com/user-attachments/assets/932f37d3-6298-42d5-95a3-2e6e3d8aa537)

With long player name + item name, the string might be too long and slightly go outside of the graphical frame, but for now this can't be avoided since line breaks are not handled in game's code for that text.

---

Both were tested and working well.