### PR TITLE
Fix common exception when landing on Yeedil

### DIFF
--- a/Rac2Client.py
+++ b/Rac2Client.py
@@ -162,9 +162,10 @@ async def pcsx2_sync_task(ctx: Rac2Context):
 
 
 async def handle_check_goal_complete(ctx: Rac2Context):
-    if ctx.current_planet is Rac2Planet.Yeedil and ctx.game_interface.get_moby(197).state == 0x11:
-        await ctx.send_msgs([{"cmd": "StatusUpdate", "status": ClientStatus.CLIENT_GOAL}])
-    pass
+    if ctx.current_planet is Rac2Planet.Yeedil:
+        moby = ctx.game_interface.get_moby(197)
+        if moby is not None and ctx.game_interface.get_moby(197).state == 0x11:
+            await ctx.send_msgs([{"cmd": "StatusUpdate", "status": ClientStatus.CLIENT_GOAL}])
 
 
 async def handle_deathlink(ctx: Rac2Context):


### PR DESCRIPTION
Since the client update rate was increased, it happens fairly commonly to have an exception popping in the client window when landing on Yeedil in the `handle_check_goal_complete`.

This is because moby 197 was not being found, and I suspect it happens because the increased update rate increases the odds that we process a tick where that moby is not loaded yet but we're already on Yeedil.

This PR simply fixes this by checking if the moby is None before trying to access its state.