### PR TITLE
Cutscene QOL

### DIFF
--- a/Callbacks.py
+++ b/Callbacks.py
@@ -46,6 +46,9 @@ def init(ctx: 'Rac2Context'):
     if ctx.current_planet is Rac2Planet.Title_Screen or ctx.current_planet is None:
         return
 
+    # Allow skipping cutscenes by only pressing START on loaded saves.
+    ctx.game_interface.pcsx2_interface.write_int8(ctx.game_interface.addresses.easy_cutscene_skip, 0x1)
+
     # Ship Wupash if option is enabled.
     if ctx.slot_data.get("skip_wupash_nebula", False):
         ctx.game_interface.pcsx2_interface.write_int8(ctx.game_interface.addresses.wupash_complete_flag, 1)

--- a/Container.py
+++ b/Container.py
@@ -150,6 +150,9 @@ def generate_patch(world: "Rac2World", patch: Rac2ProcedurePatch, instruction=No
     patch.write_token(APTokenTypes.WRITE, addresses.TITLE_SCREEN_MAIN_FUNC + 0x8F0, bytes([0xF5, 0x8B, 0x80, 0xA3]))
     patch.write_token(APTokenTypes.WRITE, addresses.QUIT_TITLE_MAIN_FUNC + 0x830, bytes([0xF5, 0x8B, 0x80, 0xA3]))
 
+    # Allow intro cinematic to be skipped by not setting this variable that blocks the ability to skip it.
+    patch.write_token(APTokenTypes.WRITE, addresses.TITLE_SCREEN_MAIN_FUNC + 0x524, MIPS.nop())
+
     # Disable game failsafe that unlocks any planet we land on if we don't have it unlocked already.
     for address in addresses.SETUP_PLANET_FUNCS:
         patch.write_token(APTokenTypes.WRITE, address + 0x144, bytes([0x07, 0x00, 0x00, 0x10]))

--- a/data/RamAddresses.py
+++ b/data/RamAddresses.py
@@ -57,6 +57,7 @@ class Addresses:
 
             self.equipped_weapon: int = 0x1A7398
             self.quickselect: int = 0x1A73B8
+            self.easy_cutscene_skip: int = 0x1A7478
             self.current_planet: int = 0x1A79F0
             self.current_bolts: int = 0x1A79F8
             # self.raritanium_count: int = 0x1A79FC


### PR DESCRIPTION
- Made title cinematic skip-able when first opening the game
- Allow skipping cutscenes by only pressing `START` on loaded saves

Through some searching, I found the variable that controls cutscene skip-ability. It is a global at address `0x001A7478` that I'm calling `easy_cutscene_skip`. It behaves different on title screen vs on planets. On planets, it's quite straight forward. 0 means you must hold `L1+R1+L2+R2+START` to skip and 1 means you just need to press `START`. For title screen, early boot sets this value to 3. If it is 3, the opening cinematic can't be skipped. If it is anything else, the opening cinematic can be skipped.

All I do is NOP the instruction that sets `easy_cutscene_skip` to 3 on boot and have the client set it to 1 on `init` callback.