### PR TITLE
Fix Smolg Warehouse PB logic

### DIFF
--- a/Logic.py
+++ b/Logic.py
@@ -656,7 +656,7 @@ def smolg_warehouse_pb_rule(state: CollectionState, player: int) -> bool:
         return True
 
     return (can_dynamo(state, player)
-            or can_improved_jump(state, player))
+            and can_improved_jump(state, player))
 
 
 def damosel_hypnotist_rule(state: CollectionState, player: int) -> bool:


### PR DESCRIPTION
1st person logic PR created a regression in Smolg's Warehouse PB logic, requiring **either** the dynamo **or** a pack.

This PR fixes that mistake by changing the requirements back to having both items.