### PR TITLE
Dynamic PINE implementation

### DIFF
--- a/Rac2Client.py
+++ b/Rac2Client.py
@@ -54,13 +54,13 @@ def ensure_pine_settings(ini_path: str, port: int = 28011):
     # --- EmuCore section ---
     if 'EmuCore' not in config:
         config['EmuCore'] = {}
-    config['EmuCore']['enablepine'] = 'true'
-    config['EmuCore']['pineslot'] = str(port)
+    config['EmuCore']['EnablePINE'] = 'true'
+    config['EmuCore']['PINESlot'] = str(port)
 
     # --- Achievements section ---
     if 'Achievements' not in config:
         config['Achievements'] = {}
-    config['Achievements']['enabled'] = 'false'
+    config['Achievements']['Enabled'] = 'false'
 
     # Write updated config
     with open(ini_path, 'w') as f:

--- a/Rac2Client.py
+++ b/Rac2Client.py
@@ -36,15 +36,15 @@ def find_free_port(start=28021, end=28031):
     return 28011  # fallback default
 
 def ensure_pine_settings(ini_path: str, port: int = 28011):
-    """Ensure INI has [EmuCore] and [Achievements] configured for Pine"""
+    """Ensure INI has configuration for PINE."""
     config = ConfigParser()
-    config.optionxform = str  # preserve key case
+    config.optionxform = str  # Preserve key case exactly
 
     ini_dir = os.path.dirname(ini_path)
     if not os.path.exists(ini_dir):
         os.makedirs(ini_dir, exist_ok=True)
 
-    # Create a minimal INI file if it doesn't exist but the directory is valid
+    # Create minimal INI if missing
     if not os.path.exists(ini_path):
         with open(ini_path, 'w') as f:
             f.write("[EmuCore]\n")
@@ -54,20 +54,31 @@ def ensure_pine_settings(ini_path: str, port: int = 28011):
     # --- EmuCore section ---
     if 'EmuCore' not in config:
         config['EmuCore'] = {}
+    # Normalize capitalization
+    for key in list(config['EmuCore'].keys()):
+        if key.lower() == 'enablepine' and key != 'EnablePINE':
+            config['EmuCore']['EnablePINE'] = config['EmuCore'].pop(key)
+        elif key.lower() == 'pineslot' and key != 'PINESlot':
+            config['EmuCore']['PINESlot'] = config['EmuCore'].pop(key)
+    # Ensure required settings exist and are correct
     config['EmuCore']['EnablePINE'] = 'true'
     config['EmuCore']['PINESlot'] = str(port)
 
     # --- Achievements section ---
     if 'Achievements' not in config:
         config['Achievements'] = {}
+    # Normalize capitalization
+    for key in list(config['Achievements'].keys()):
+        if key.lower() == 'enabled' and key != 'Enabled':
+            config['Achievements']['Enabled'] = config['Achievements'].pop(key)
     config['Achievements']['Enabled'] = 'false'
 
-    # Write updated config
+    # Write updated config back
     with open(ini_path, 'w') as f:
         config.write(f)
 
 def setup_pine():
-    """Determine port and create Pine instance early"""
+    """Determine port and create Pine instance"""
     host_settings = get_settings()
     game_ini = host_settings.get('rac2_options', {}).get('game_ini')
 

--- a/Rac2Client.py
+++ b/Rac2Client.py
@@ -8,6 +8,7 @@ import os
 import subprocess
 import traceback
 import socket
+import platform
 import tkinter as tk
 from tkinter import filedialog
 
@@ -96,14 +97,15 @@ def setup_pine():
 # Run early so Pine instance exists for Rac2Interface
 pine_port = setup_pine()
 
-def validate_rac2_settings():
-    """Validate rac2_options from host.yaml before continuing."""
+def validate_rac2_settings() -> bool:
+    """Validate rac2_options from host.yaml before continuing.
+    Logs warnings but does not abort."""
     host_settings = get_settings()
     rac2_opts = host_settings.get("rac2_options", {})
 
     problems = []
 
-    # ISO file
+    # ISO file check
     iso_file = rac2_opts.get("iso_file")
     if not iso_file:
         problems.append("Missing 'iso_file' in rac2_options.")
@@ -114,14 +116,21 @@ def validate_rac2_settings():
 
     # ISO start (PCSX2 path)
     iso_start = rac2_opts.get("iso_start")
-    if iso_start in (None, ""):
-        problems.append("Missing 'iso_start' — should be path to PCSX2.")
+    if not iso_start:
+        problems.append("Missing 'iso_start' — should be path to PCSX2 executable.")
     elif isinstance(iso_start, str):
         iso_start_expanded = os.path.expandvars(os.path.expanduser(iso_start))
         if not os.path.isfile(iso_start_expanded):
             problems.append(f"'iso_start' path does not exist: {iso_start_expanded}")
-        elif not iso_start_expanded.lower().endswith(("pcsx2.exe", "pcsx2-qt.exe")):
-            problems.append(f"'iso_start' doesn't look like a PCSX2 executable (pcsx2.exe or pcsx2-qt.exe): {iso_start_expanded}")
+        else:
+            system = platform.system().lower()
+            exe_name = os.path.basename(iso_start_expanded).lower()
+            # Windows check
+            if system == "windows" and not exe_name.endswith(("pcsx2.exe", "pcsx2-qt.exe")):
+                problems.append(f"On Windows, PCSX2 executable usually ends with pcsx2.exe — got {exe_name}")
+            # Linux/macOS check
+            elif system in ("linux", "darwin") and "pcsx2" not in exe_name:
+                problems.append(f"Expected 'pcsx2' binary on {system.capitalize()}, got {exe_name}")
 
     # Game INI
     game_ini = rac2_opts.get("game_ini")
@@ -132,16 +141,22 @@ def validate_rac2_settings():
         if not os.path.isfile(game_ini_expanded):
             problems.append(f"Game INI not found: {game_ini_expanded}")
 
-    # Report
+    # Always warn, never block
     if problems:
-        logger.warning("Rac2 configuration issues detected:")
+        logger.warning("⚠ Rac2 configuration issues detected:")
         for p in problems:
             logger.warning(f"  - {p}")
-        logger.warning("Please check your host.yaml rac2_options section, and restart.")
-        return False
+        logger.warning("Continuing anyway; the game may still launch normally.")
 
-    # logger.info("rac2_options verified successfully.")
-    return True
+        # Notify user in-client
+        try:
+            ctx = globals().get("ctx")  # use context if available
+            if ctx and hasattr(ctx, "notification_manager"):
+                ctx.notification_manager.queue_notification("Some RAC2 config issues found (see above). Continuing anyway.")
+        except Exception:
+            pass
+
+    return True  # Always return True now
 
 class Rac2CommandProcessor(ClientCommandProcessor):
     def __init__(self, ctx: CommonContext):

--- a/Rac2Client.py
+++ b/Rac2Client.py
@@ -25,6 +25,7 @@ from configparser import ConfigParser
 
 
 def find_free_port(start=28021, end=28031):
+    """Find free port for PINE"""
     for port in range(start, end + 1):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             try:
@@ -32,29 +33,51 @@ def find_free_port(start=28021, end=28031):
                 return port
             except OSError:
                 continue
-    return 28011
+    return 28011  # fallback default
 
-def set_pine_port(ini_path, port):
+
+def ensure_pine_settings(ini_path: str, port: int = 28011):
+    """Ensure INI has [EmuCore] with enablepine and pineslot set correctly"""
     config = ConfigParser()
-    config.read(ini_path)
-    if 'EmuCore' in config and 'PINESlot' in config['EmuCore']:
-        config['EmuCore']['PINESlot'] = str(port)
+    config.optionxform = str  # preserve key case
+    
+    # If INI file missing but path valid → create a minimal one
+    if not os.path.exists(ini_path) and os.path.isdir(os.path.dirname(ini_path)):
         with open(ini_path, 'w') as f:
-            config.write(f)
+            f.write("[EmuCore]\n")
+    
+    config.read(ini_path)
+
+    # --- EmuCore section ---
+    if 'EmuCore' not in config:
+        config['EmuCore'] = {}
+    config['EmuCore']['enablepine'] = 'true'
+    config['EmuCore']['PINESlot'] = str(port)
+
+    # --- Achievements section ---
+    if 'Achievements' not in config:
+        config['Achievements'] = {}
+    config['Achievements']['enabled'] = 'false'
+
+    # Write back to disk
+    with open(ini_path, 'w') as f:
+        config.write(f)
+
 
 def setup_pine():
     """Determine port and create Pine instance early"""
     host_settings = get_settings()
     game_ini = host_settings.get('rac2_options', {}).get('game_ini')
 
-    if game_ini and os.path.exists(game_ini):
+    if game_ini and os.path.exists(os.path.dirname(game_ini)):
         port = find_free_port()
-        set_pine_port(game_ini, port)
+        ensure_pine_settings(game_ini, port)
     else:
         port = 28011
 
     create_pine_interface(port)
     return port
+
 
 # Run early so Pine instance exists for Rac2Interface
 pine_port = setup_pine()

--- a/Rac2Client.py
+++ b/Rac2Client.py
@@ -35,6 +35,7 @@ def find_free_port(start=28021, end=28031):
                 continue
     return 28011  # fallback default
 
+
 def ensure_pine_settings(ini_path: str, port: int = 28011):
     """Ensure INI has configuration for PINE."""
     config = ConfigParser()
@@ -77,19 +78,21 @@ def ensure_pine_settings(ini_path: str, port: int = 28011):
     with open(ini_path, 'w') as f:
         config.write(f)
 
+
 def setup_pine():
-    """Determine port and create Pine instance"""
+    """Determine port and create Pine instance."""
     host_settings = get_settings()
     game_ini = host_settings.get('rac2_options', {}).get('game_ini')
 
+    # Only pick port here; do not touch ini yet
     if game_ini and os.path.exists(os.path.dirname(game_ini)):
         port = find_free_port()
-        ensure_pine_settings(game_ini, port)
     else:
         port = 28011
 
     create_pine_interface(port)
     return port
+
 
 # Run early so Pine instance exists for Rac2Interface
 pine_port = setup_pine()
@@ -319,6 +322,7 @@ async def run_game(iso_file):
 
 
 async def patch_and_run_game(aprac2_file: str):
+    """Patch ISO if needed, ensure copied INI has correct PINE configuration, and launch game."""
     settings: Optional[Rac2Settings] = get_settings().get("rac2_options", False)
     assert settings, "No Rac2 Settings?"
 
@@ -326,7 +330,7 @@ async def patch_and_run_game(aprac2_file: str):
     base_name = os.path.splitext(aprac2_file)[0]
     output_path = base_name + '.iso'
 
-    # --- Always determine CRC + version once the ISO exists or is created ---
+    # Patch ISO if missing
     if not os.path.exists(output_path):
         from .PatcherUI import PatcherUI
         patcher = PatcherUI(aprac2_file, output_path, logger)
@@ -342,10 +346,13 @@ async def patch_and_run_game(aprac2_file: str):
             file_name = f"{version}_{crc:X}.ini"
             file_path = os.path.join(os.path.dirname(game_ini_path), file_name)
 
-            # Always ensure up-to-date settings (even if ISO already existed)
+            # Always create or refresh a CRC-based ini copy
             shutil.copy(game_ini_path, file_path)
             ensure_pine_settings(file_path, pine_port)
-            logger.info(f"Configured PINE on port {pine_port} in {os.path.basename(file_path)}")
+
+            logger.info(f"Configured PINE (port {pine_port}) in {os.path.basename(file_path)}")
+    else:
+        logger.warning("No valid game_ini found; skipping INI setup.")
 
     Utils.async_start(run_game(output_path))
 

--- a/Rac2Client.py
+++ b/Rac2Client.py
@@ -7,6 +7,7 @@ import multiprocessing
 import os
 import subprocess
 import traceback
+import socket
 
 from CommonClient import ClientCommandProcessor, CommonContext, get_base_parser, logger, server_loop, gui_enabled
 from NetUtils import ClientStatus
@@ -20,6 +21,44 @@ from .Callbacks import update, init
 from .ClientReceiveItems import handle_received_items
 from .NotificationManager import NotificationManager
 from .Rac2Interface import HUD_MESSAGE_DURATION, ConnectionState, Rac2Interface, Rac2Planet
+from configparser import ConfigParser
+from .Rac2Interface import create_pine_interface, Rac2Interface
+
+
+def find_free_port(start=28021, end=28031):
+    for port in range(start, end + 1):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                s.bind(("127.0.0.1", port))
+                return port
+            except OSError:
+                continue
+    return 28011
+
+def set_pine_port(ini_path, port):
+    config = ConfigParser()
+    config.read(ini_path)
+    if 'EmuCore' in config and 'PINESlot' in config['EmuCore']:
+        config['EmuCore']['PINESlot'] = str(port)
+        with open(ini_path, 'w') as f:
+            config.write(f)
+
+def setup_pine():
+    """Determine port and create Pine instance early"""
+    host_settings = get_settings()
+    game_ini = host_settings.get('rac2_options', {}).get('game_ini')
+
+    if game_ini and os.path.exists(game_ini):
+        port = find_free_port()
+        set_pine_port(game_ini, port)
+    else:
+        port = 28011
+
+    create_pine_interface(port)
+    return port
+
+# Run early so Pine instance exists for Rac2Interface
+pine_port = setup_pine()
 
 
 class Rac2CommandProcessor(ClientCommandProcessor):
@@ -293,7 +332,6 @@ def get_pcsx2_crc(iso_path: str) -> Optional[int]:
             crc ^= int.from_bytes(iso_file.read(4), "little")
 
     return crc
-
 
 def launch():
     Utils.init_logging("RAC2 Client")

--- a/Rac2Client.py
+++ b/Rac2Client.py
@@ -8,6 +8,8 @@ import os
 import subprocess
 import traceback
 import socket
+import tkinter as tk
+from tkinter import filedialog
 
 from CommonClient import ClientCommandProcessor, CommonContext, get_base_parser, logger, server_loop, gui_enabled
 from NetUtils import ClientStatus
@@ -34,7 +36,6 @@ def find_free_port(start=28021, end=28031):
             except OSError:
                 continue
     return 28011  # fallback default
-
 
 def ensure_pine_settings(ini_path: str, port: int = 28011):
     """Ensure INI has configuration for PINE."""
@@ -78,7 +79,6 @@ def ensure_pine_settings(ini_path: str, port: int = 28011):
     with open(ini_path, 'w') as f:
         config.write(f)
 
-
 def setup_pine():
     """Determine port and create Pine instance."""
     host_settings = get_settings()
@@ -93,10 +93,55 @@ def setup_pine():
     create_pine_interface(port)
     return port
 
-
 # Run early so Pine instance exists for Rac2Interface
 pine_port = setup_pine()
 
+def validate_rac2_settings():
+    """Validate rac2_options from host.yaml before continuing."""
+    host_settings = get_settings()
+    rac2_opts = host_settings.get("rac2_options", {})
+
+    problems = []
+
+    # ISO file
+    iso_file = rac2_opts.get("iso_file")
+    if not iso_file:
+        problems.append("Missing 'iso_file' in rac2_options.")
+    else:
+        iso_file_expanded = os.path.expandvars(os.path.expanduser(iso_file))
+        if not os.path.isfile(iso_file_expanded):
+            problems.append(f"ISO file not found: {iso_file_expanded}")
+
+    # ISO start (PCSX2 path)
+    iso_start = rac2_opts.get("iso_start")
+    if iso_start in (None, ""):
+        problems.append("Missing 'iso_start' — should be path to PCSX2.")
+    elif isinstance(iso_start, str):
+        iso_start_expanded = os.path.expandvars(os.path.expanduser(iso_start))
+        if not os.path.isfile(iso_start_expanded):
+            problems.append(f"'iso_start' path does not exist: {iso_start_expanded}")
+        elif not iso_start_expanded.lower().endswith(("pcsx2.exe", "pcsx2-qt.exe")):
+            problems.append(f"'iso_start' doesn't look like a PCSX2 executable (pcsx2.exe or pcsx2-qt.exe): {iso_start_expanded}")
+
+    # Game INI
+    game_ini = rac2_opts.get("game_ini")
+    if not game_ini:
+        problems.append("Missing 'game_ini' path — should point to a PCSX2 game settings INI file.")
+    else:
+        game_ini_expanded = os.path.expandvars(os.path.expanduser(game_ini))
+        if not os.path.isfile(game_ini_expanded):
+            problems.append(f"Game INI not found: {game_ini_expanded}")
+
+    # Report
+    if problems:
+        logger.warning("Rac2 configuration issues detected:")
+        for p in problems:
+            logger.warning(f"  - {p}")
+        logger.warning("Please check your host.yaml rac2_options section, and restart.")
+        return False
+
+    # logger.info("rac2_options verified successfully.")
+    return True
 
 class Rac2CommandProcessor(ClientCommandProcessor):
     def __init__(self, ctx: CommonContext):
@@ -133,6 +178,51 @@ class Rac2CommandProcessor(ClientCommandProcessor):
             message = f"Deathlink {'enabled' if self.ctx.death_link_enabled else 'disabled'}"
             logger.info(message)
             self.ctx.notification_manager.queue_notification(message)
+
+    def _cmd_start(self):
+        """Select and start with a .aprac2 patch file."""
+        if not isinstance(self.ctx, Rac2Context):
+            logger.error("Not in a valid RAC2 context.")
+            return
+
+        # Prevent launching if already connected to PCSX2
+        if self.ctx.game_interface.get_connection_state():
+            msg = "Already connected to Ratchet & Clank 2 / PCSX2 — please close old instance or open another client."
+            logger.warning(msg)
+            self.ctx.notification_manager.queue_notification(msg)
+            return
+
+        # Validate rac2 host.yaml options
+        if not validate_rac2_settings():
+            return
+
+        # Open file dialog
+        root = tk.Tk()
+        root.withdraw()
+        file_path = filedialog.askopenfilename(
+            title="Select a Ratchet & Clank 2 .aprac2 file",
+            filetypes=[("Archipelago RAC2 Patch Files", "*.aprac2"), ("All Files", "*.*")]
+        )
+        root.destroy()
+
+        if not file_path:
+            logger.info("No file selected.")
+            return
+
+        # Launch async patching + game startup
+        logger.info(f"Selected patch: {file_path}")
+        self.ctx.notification_manager.queue_notification("Launching selected patch file...")
+
+        async def start_patch():
+            try:
+                await patch_and_run_game(file_path)
+                self.ctx.auth = get_name_from_aprac2(file_path)
+                logger.info("Game launch initiated.")
+            except Exception as e:
+                logger.error(f"Failed to start patch: {e}")
+                self.ctx.notification_manager.queue_notification(f"Error: {e}")
+
+        Utils.async_start(start_patch(), name="Manual Patch Launch")
 
 
 class Rac2Context(CommonContext):

--- a/Rac2Client.py
+++ b/Rac2Client.py
@@ -20,9 +20,8 @@ from .ClientCheckLocations import handle_checked_location
 from .Callbacks import update, init
 from .ClientReceiveItems import handle_received_items
 from .NotificationManager import NotificationManager
-from .Rac2Interface import HUD_MESSAGE_DURATION, ConnectionState, Rac2Interface, Rac2Planet
+from .Rac2Interface import HUD_MESSAGE_DURATION, ConnectionState, create_pine_interface, Rac2Interface, Rac2Planet
 from configparser import ConfigParser
-from .Rac2Interface import create_pine_interface, Rac2Interface
 
 
 def find_free_port(start=28021, end=28031):

--- a/Rac2Client.py
+++ b/Rac2Client.py
@@ -9,6 +9,7 @@ import subprocess
 import traceback
 import socket
 import platform
+import errno
 import tkinter as tk
 from tkinter import filedialog
 
@@ -26,17 +27,53 @@ from .NotificationManager import NotificationManager
 from .Rac2Interface import HUD_MESSAGE_DURATION, ConnectionState, create_pine_interface, Rac2Interface, Rac2Planet
 from configparser import ConfigParser
 
+DEFAULT_PINE_PORT = 28011
 
 def find_free_port(start=28021, end=28031):
-    """Find free port for PINE"""
+    system_name = platform.system()
+
+    # On Windows, keep the old TCP-based logic
+    if system_name == "Windows":
+        for port in range(start, end + 1):
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                try:
+                    s.bind(("127.0.0.1", port))
+                    return port
+                except OSError:
+                    continue
+        return DEFAULT_PINE_PORT
+
+    # On Linux/macOS, check for existing socket files instead
+    base_dir = os.environ.get("XDG_RUNTIME_DIR") or os.environ.get("TMPDIR") or "/tmp"
+
     for port in range(start, end + 1):
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        if port == DEFAULT_PINE_PORT:
+            sock_path = os.path.join(base_dir, "pcsx2.sock")
+        else:
+            sock_path = os.path.join(base_dir, f"pcsx2.sock.{port}")
+
+        # If socket file exists, test whether it’s actually active
+        if os.path.exists(sock_path):
             try:
-                s.bind(("127.0.0.1", port))
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
+                    s.connect(sock_path)
+                    # If we connected, it’s in use
+                    continue
+            except OSError as e:
+                # Connection failed → likely stale socket file, safe to remove
+                if e.errno in (errno.ECONNREFUSED, errno.ENOENT):
+                    try:
+                        os.remove(sock_path)
+                    except OSError:
+                        pass
+                # In either case, we can reuse this port now
                 return port
-            except OSError:
-                continue
-    return 28011  # fallback default
+        else:
+            # No such file → definitely free
+            return port
+
+    # Fallback if all taken
+    return DEFAULT_PINE_PORT
 
 def ensure_pine_settings(ini_path: str, port: int = 28011):
     """Ensure INI has configuration for PINE."""

--- a/Rac2Client.py
+++ b/Rac2Client.py
@@ -35,34 +35,36 @@ def find_free_port(start=28021, end=28031):
                 continue
     return 28011  # fallback default
 
-
 def ensure_pine_settings(ini_path: str, port: int = 28011):
-    """Ensure INI has [EmuCore] with enablepine and pineslot set correctly"""
+    """Ensure INI has [EmuCore] and [Achievements] configured for Pine"""
     config = ConfigParser()
     config.optionxform = str  # preserve key case
-    
-    # If INI file missing but path valid → create a minimal one
-    if not os.path.exists(ini_path) and os.path.isdir(os.path.dirname(ini_path)):
+
+    ini_dir = os.path.dirname(ini_path)
+    if not os.path.exists(ini_dir):
+        os.makedirs(ini_dir, exist_ok=True)
+
+    # Create a minimal INI file if it doesn't exist but the directory is valid
+    if not os.path.exists(ini_path):
         with open(ini_path, 'w') as f:
             f.write("[EmuCore]\n")
-    
+
     config.read(ini_path)
 
     # --- EmuCore section ---
     if 'EmuCore' not in config:
         config['EmuCore'] = {}
     config['EmuCore']['enablepine'] = 'true'
-    config['EmuCore']['PINESlot'] = str(port)
+    config['EmuCore']['pineslot'] = str(port)
 
     # --- Achievements section ---
     if 'Achievements' not in config:
         config['Achievements'] = {}
     config['Achievements']['enabled'] = 'false'
 
-    # Write back to disk
+    # Write updated config
     with open(ini_path, 'w') as f:
         config.write(f)
-
 
 def setup_pine():
     """Determine port and create Pine instance early"""
@@ -77,7 +79,6 @@ def setup_pine():
 
     create_pine_interface(port)
     return port
-
 
 # Run early so Pine instance exists for Rac2Interface
 pine_port = setup_pine()
@@ -314,6 +315,7 @@ async def patch_and_run_game(aprac2_file: str):
     base_name = os.path.splitext(aprac2_file)[0]
     output_path = base_name + '.iso'
 
+    # --- Always determine CRC + version once the ISO exists or is created ---
     if not os.path.exists(output_path):
         from .PatcherUI import PatcherUI
         patcher = PatcherUI(aprac2_file, output_path, logger)
@@ -328,7 +330,11 @@ async def patch_and_run_game(aprac2_file: str):
         if version and crc:
             file_name = f"{version}_{crc:X}.ini"
             file_path = os.path.join(os.path.dirname(game_ini_path), file_name)
+
+            # Always ensure up-to-date settings (even if ISO already existed)
             shutil.copy(game_ini_path, file_path)
+            ensure_pine_settings(file_path, pine_port)
+            logger.info(f"Configured PINE on port {pine_port} in {os.path.basename(file_path)}")
 
     Utils.async_start(run_game(output_path))
 

--- a/Rac2Client.py
+++ b/Rac2Client.py
@@ -485,7 +485,7 @@ async def patch_and_run_game(aprac2_file: str):
         version = Rac2ProcedurePatch.get_game_version_from_iso(output_path)
         crc = get_pcsx2_crc(output_path)
         if version and crc:
-            file_name = f"{version}_{crc:X}.ini"
+            file_name = f"{version}_{crc:08X}.ini"
             file_path = os.path.join(os.path.dirname(game_ini_path), file_name)
 
             # Always create or refresh a CRC-based ini copy

--- a/Rac2Interface.py
+++ b/Rac2Interface.py
@@ -452,10 +452,16 @@ def planet_by_id(planet_id) -> Optional[Rac2Planet]:
 #     current_amount: int
 #     current_capacity: int
 
+pcsx2_interface: Pine | None = None
+
+def create_pine_interface(slot: int = 28011):
+    global pcsx2_interface
+    pcsx2_interface = Pine(slot=slot)
 
 class Rac2Interface:
     """Interface sitting in front of the pcsx2_interface to provide higher level functions for interacting with RAC2"""
-    pcsx2_interface: Pine = Pine()
+    # Pass the dynamic port if available
+    pcsx2_interface: Pine | None = None  # This will be set via create_pine_interface()
     addresses: Addresses = None
     vendor: Vendor = None
     connection_status: str
@@ -469,6 +475,8 @@ class Rac2Interface:
     def __init__(self, logger) -> None:
         self.logger = logger
         self.vendor = Vendor(self)
+        global pcsx2_interface
+        self.pcsx2_interface = pcsx2_interface
 
     def give_equipment_to_player(self, equipment: EquipmentData):
         if isinstance(equipment, WeaponData) and equipment.base_weapon_offset is not None:

--- a/__init__.py
+++ b/__init__.py
@@ -33,6 +33,37 @@ class Rac2Settings(settings.Group):
         description = "Ratchet & Clank 2 PS2 ISO file"
         copy_to = "Ratchet & Clank 2.iso"
 
+    def copy(self, target_dir: str):
+        """Copy ISO and confirm the copy is complete."""
+        from CommonClient import logger  # safely import logger here to avoid circular imports
+
+        src = os.path.expanduser(os.path.expandvars(self.value))
+        if not os.path.isfile(src):
+            raise FileNotFoundError(f"Ratchet & Clank 2 ISO not found: {src}")
+
+        dst = os.path.join(target_dir, os.path.basename(self.copy_to))
+
+        logger.info("Copying ISO to Archipelago directory — please don't close the client...")
+        logger.info(f"Source: {os.path.basename(src)} — Destination: {dst}")
+
+        # Perform copy
+        result = super().copy(target_dir)
+
+        # Verify sizes match exactly
+        src_size = os.path.getsize(src)
+        dst_size = os.path.getsize(dst)
+
+        if src_size != dst_size:
+            raise IOError(
+                f"ISO copy verification failed.\n"
+                f"Source: {src_size:,} bytes\n"
+                f"Copied: {dst_size:,} bytes\n"
+                f"({dst} may be incomplete or corrupted)"
+            )
+
+        logger.info("ISO copy completed successfully.")
+        return result
+
     class IsoStart(str):
         """
         Set this false to never autostart an iso (such as after patching),

--- a/__init__.py
+++ b/__init__.py
@@ -33,37 +33,6 @@ class Rac2Settings(settings.Group):
         description = "Ratchet & Clank 2 PS2 ISO file"
         copy_to = "Ratchet & Clank 2.iso"
 
-    def copy(self, target_dir: str):
-        """Copy ISO and confirm the copy is complete."""
-        from CommonClient import logger  # safely import logger here to avoid circular imports
-
-        src = os.path.expanduser(os.path.expandvars(self.value))
-        if not os.path.isfile(src):
-            raise FileNotFoundError(f"Ratchet & Clank 2 ISO not found: {src}")
-
-        dst = os.path.join(target_dir, os.path.basename(self.copy_to))
-
-        logger.info("Copying ISO to Archipelago directory — please don't close the client...")
-        logger.info(f"Source: {os.path.basename(src)} — Destination: {dst}")
-
-        # Perform copy
-        result = super().copy(target_dir)
-
-        # Verify sizes match exactly
-        src_size = os.path.getsize(src)
-        dst_size = os.path.getsize(dst)
-
-        if src_size != dst_size:
-            raise IOError(
-                f"ISO copy verification failed.\n"
-                f"Source: {src_size:,} bytes\n"
-                f"Copied: {dst_size:,} bytes\n"
-                f"({dst} may be incomplete or corrupted)"
-            )
-
-        logger.info("ISO copy completed successfully.")
-        return result
-
     class IsoStart(str):
         """
         Set this false to never autostart an iso (such as after patching),

--- a/pcsx2_interface/pine.py
+++ b/pcsx2_interface/pine.py
@@ -71,30 +71,33 @@ class Pine:
         # self._init_socket()
 
     def _init_socket(self) -> None:
-        if system() == "Windows":
-            socket_family = socket.AF_INET
-            socket_name = ("127.0.0.1", self._slot)
-        elif system() == "Linux":
-            socket_family = socket.AF_UNIX
-            socket_name = os.environ.get("XDG_RUNTIME_DIR", "/tmp")
-            socket_name += "/pcsx2.sock"
-        elif system() == "Darwin":
-            socket_family = socket.AF_UNIX
-            socket_name = os.environ.get("TMPDIR", "/tmp")
-            socket_name += "/pcsx2.sock"
-        else:
-            socket_family = socket.AF_UNIX
-            socket_name = "/tmp/pcsx2.sock"
-
+        system_name = system()
         try:
+            if system_name == "Windows":
+                socket_family = socket.AF_INET
+                socket_name = ("127.0.0.1", self._slot)
+            elif system_name in ("Linux", "Darwin"):
+                socket_family = socket.AF_UNIX
+                # Use XDG_RUNTIME_DIR or fallback to /tmp
+                base_dir = os.environ.get("XDG_RUNTIME_DIR") or os.environ.get("TMPDIR") or "/tmp"
+                # PCSX2 uses `.sock` for 28011, otherwise `.sock.<PORT>`
+                if self._slot == 28011:
+                    socket_name = os.path.join(base_dir, "pcsx2.sock")
+                else:
+                    socket_name = os.path.join(base_dir, f"pcsx2.sock.{self._slot}")
+            else:
+                # Fallback for unknown UNIX-like systems
+                socket_family = socket.AF_UNIX
+                socket_name = f"/tmp/pcsx2.sock.{self._slot}" if self._slot != 28011 else "/tmp/pcsx2.sock"
+    
             self._sock = socket.socket(socket_family, socket.SOCK_STREAM)
             self._sock.settimeout(5.0)
             self._sock.connect(socket_name)
-        except socket.error:
+        except socket.error as e:
             self._sock.close()
             self._sock_state = False
             return
-
+    
         self._sock_state = True
 
     def connect(self) -> None:


### PR DESCRIPTION
This is a way for having dynamic PINE port set for each instance of the client/PCSX2
Allowing you to run multiple instances at the same time & play without issues.
Currently it adds a `/start` command to manually launch from within the client.
There's some checks and non-halting errors for if you're missing `host.yaml` settings
Would like to improve it more, but honestly my knowledge of AP coding is quite limited so here's what i have so far.

Myself, and a few other people have tested it fine without issue.
Only problems we've noticed if you start instances too quickly PINE can become desynced.
If you don't have an iso set and run `/start` it will give an error, and not prompt for `.aprac2`. Running command again works tho.
Also tried warning the user to not close client while moving iso. But couldn't get it working smoothly so has been removed.

Let me know if any changes are needed. Currently include a lot of comments for sections i've changed.
Gonna include what i had in my release notes here:
# Release notes
Testing Dynamic PINE ports for multi PCSX2 instance support.
Based on: https://github.com/evilwb/APRac2/releases/tag/v0.6.4

### Setup
You need every RaC2 option in your `host.yaml` setup. That means:  
`iso_file` to a valid vanilla iso in your Archipelago directory (should be already from normal setup)  
`iso_start` to your PCSX2 exe (Make sure to use `/`)  
`game_ini` to a game settings file in your PCSX2's gamesettings folder.  
(Usually `%USERPROFILE%/Documents/PCSX2/gamesettings/SCUS-97268_38996035.ini`)

Example:
```yaml
rac2_options:
  # File name of the Ratchet & Clank 2 ISO
  iso_file: "Ratchet & Clank - Going Commando (USA) (v1.01).iso"
  # Set this false to never autostart an iso (such as after patching),
  # Set it to true to have the operating system default program open the iso
  # Alternatively, set it to a path to a program to open the .iso file with (like PCSX2)
  iso_start: "C:/Emulators/(PS2) PCSX2/pcsx2-qt.exe"
  # Set to file path to an existing PCSX2 game setting INI file to have the patcher
  # create an appropriately named INI with the rest of the patch output. This can be used to
  # allow you to use you own custom PCSX2 setting with patched ISO.
  game_ini: "%USERPROFILE%/Documents/PCSX2/gamesettings/SCUS-97268_38996035.ini"
```

Game settings ini example:
```ini
[EmuCore]
EnablePINE = true
PINESlot = 28011

[Achievements]
Enabled = false

[MemoryCards]
Slot1_Enable = true
Slot2_Enable = false
Slot1_Filename = APgames.ps2
```
Recommended you use your settings for vanilla RaC2. But you can make a copy with specific edits.
So you can set an AP specific memory card like in the example above. (You don't need to add PINE settings)

For normal setup if you haven't already. Check [GitHub](<https://github.com/evilwb/APRac2/blob/main/docs/setup_en.md>), and [Discord](<https://discord.com/channels/731205301247803413/1325015730218860554/1371288772548755466>).

### Start
Simply run a `.aprac2` file with Archipelago. (Recommended to set to open `.aprac2` files with Archipelago by default)
Or run the client, and use the `/start` command, and then select your desired `.aprac2` file.
Note: You can rename `aprac2` and patched `iso` but they have to have the same name or it'll make another `iso`.
(Same way you have to keep `.apsave`, and their `.zip` name the same if hosting locally)

Full changes: <https://github.com/jacobmix/APRac2/compare/main...v0.6.5-PINE-pre>