### PR TITLE
Do not send deathlink on game start

### DIFF
--- a/Rac2Interface.py
+++ b/Rac2Interface.py
@@ -595,6 +595,8 @@ class Rac2Interface:
 
     def get_alive(self) -> bool:
         planet = self.get_current_planet()
+        if planet is None:
+            return True
         if planet in [Rac2Planet.Wupash_Nebula, Rac2Planet.Feltzin_System, Rac2Planet.Hrugis_Cloud, Rac2Planet.Gorn]:
             return self.pcsx2_interface.read_int8(self.addresses.planet[planet].camara_state) != 6
         elif planet in [Rac2Planet.Dobbo_Orbit, Rac2Planet.Damosel_Orbit]:


### PR DESCRIPTION
When the game boots, before starting a file, the value in the current planet address is 0xFFFFFFFF.
When trying to mp this value to a Rac2Planet, we get None.
However, we currently do not check against None, so we check against Ratchet's current nanotech, which is 0, thus we send a deathlink.

This PR adds a check to prevent the client from sending a deathlink when the Rac2Planet is None.