### PR TITLE
Add victory condition list

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -3,13 +3,20 @@ from typing import TYPE_CHECKING
 from BaseClasses import ItemClassification, Item
 from .data import Items, Locations
 from .data.Items import CoordData, EquipmentData, ProgressiveUpgradeData, ItemData
-from .Rac2Options import StartingWeapons
+from .Rac2Options import StartingWeapons, Rac2Options, VictoryConditions
 
 if TYPE_CHECKING:
     from . import Rac2World
 
 
-def get_classification(item: ItemData) -> ItemClassification:
+def get_classification(item: ItemData, options: Rac2Options = None) -> ItemClassification:
+    if options is not None:
+        if VictoryConditions.get_all_platinum_bolts in options.victory_conditions and item == Items.PLATINUM_BOLT:
+            return ItemClassification.progression
+        if VictoryConditions.get_all_weapons in options.victory_conditions and item in Items.LV1_WEAPONS:
+            return ItemClassification.progression
+        if VictoryConditions.get_all_gadgets in options.victory_conditions and item in Items.EQUIPMENT:
+            return ItemClassification.progression
     if item in Items.COORDS:
         return ItemClassification.progression
     if item in [
@@ -133,7 +140,11 @@ def create_equipment(world: "Rac2World") -> list["Item"]:
 def create_collectables(world: "Rac2World") -> list["Item"]:
     collectable_items: list["Item"] = []
 
-    for _ in range(20):
+    platinum_bolt_count = 20
+
+    if VictoryConditions.get_all_platinum_bolts in world.options.victory_conditions:
+        platinum_bolt_count = 40
+    for _ in range(platinum_bolt_count):
         collectable_items.append(world.create_item(Items.PLATINUM_BOLT.name))
 
     precollected_nanotech_boosts: int = len([

--- a/Rac2Client.py
+++ b/Rac2Client.py
@@ -1,7 +1,7 @@
 import json
 import shutil
 import zipfile
-from typing import Optional, cast, Dict, Any
+from typing import Optional, cast, Dict, Any, List
 import asyncio
 import multiprocessing
 import os
@@ -13,6 +13,7 @@ from NetUtils import ClientStatus
 import Utils
 from settings import get_settings
 from .data.Planets import get_all_active_locations
+from .data import Items
 from . import Rac2Settings
 from .Container import Rac2ProcedurePatch
 from .ClientCheckLocations import handle_checked_location
@@ -20,6 +21,7 @@ from .Callbacks import update, init
 from .ClientReceiveItems import handle_received_items
 from .NotificationManager import NotificationManager
 from .Rac2Interface import HUD_MESSAGE_DURATION, ConnectionState, Rac2Interface, Rac2Planet
+from .Rac2Options import VictoryConditions
 
 
 class Rac2CommandProcessor(ClientCommandProcessor):
@@ -76,6 +78,7 @@ class Rac2Context(CommonContext):
     death_link_enabled = False
     queued_deaths: int = 0
     previous_decoy_glove_ammo: int = 0
+    goals: List[Any] = []
 
     def __init__(self, server_address, password):
         super().__init__(server_address, password)
@@ -162,10 +165,8 @@ async def pcsx2_sync_task(ctx: Rac2Context):
 
 
 async def handle_check_goal_complete(ctx: Rac2Context):
-    if ctx.current_planet is Rac2Planet.Yeedil:
-        moby = ctx.game_interface.get_moby(197)
-        if moby is not None and ctx.game_interface.get_moby(197).state == 0x11:
-            await ctx.send_msgs([{"cmd": "StatusUpdate", "status": ClientStatus.CLIENT_GOAL}])
+    if all(check(ctx) for check in ctx.goals):
+        await ctx.send_msgs([{"cmd": "StatusUpdate", "status": ClientStatus.CLIENT_GOAL}])
 
 
 async def handle_deathlink(ctx: Rac2Context):
@@ -182,7 +183,59 @@ async def handle_deathlink(ctx: Rac2Context):
             ctx.is_pending_death_link_reset = True
 
 
+def get_mutated_protopet_victory_condition() -> Any:
+    return lambda ctx: (
+        ctx.current_planet is Rac2Planet.Yeedil and
+        ctx.game_interface.get_moby(197) is not None and
+        ctx.game_interface.get_moby(197).state == 0x11)
+
+
+def get_all_platinum_bolts_victory_condition() -> Any:
+    return lambda ctx: ctx.game_interface.get_current_inventory()[Items.PLATINUM_BOLT.name] >= 40
+
+
+def get_all_weapons_victory_condition() -> Any:
+    return lambda ctx: all(
+        ctx.game_interface.get_current_inventory()[item.name] > 0 for item in Items.LV1_WEAPONS
+    )
+
+
+def get_all_gadgets_victory_condition() -> Any:
+    return lambda ctx: all(
+        ctx.game_interface.get_current_inventory()[item.name] > 0 for item in Items.EQUIPMENT
+    )
+
+
+def initialize_goals(ctx: Rac2Context):
+    if ctx.slot_data is None:
+        return
+
+    goals_options = ctx.slot_data.get("victory_conditions", None)
+
+    if goals_options is None:
+        ctx.game_interface.logger.info("Goal list should not be None (Rac2Client.py). Adding Protopet as objective.")
+        ctx.goals.append(get_mutated_protopet_victory_condition())
+        return
+
+    if len(goals_options) is 0:
+        ctx.game_interface.logger.info("Goal list is empty. Adding Protopet as objective.")
+        ctx.goals.append(get_mutated_protopet_victory_condition())
+        return
+
+    if VictoryConditions.defeat_protopet in goals_options:
+        ctx.goals.append(get_mutated_protopet_victory_condition())
+    if VictoryConditions.get_all_platinum_bolts in goals_options:
+        ctx.goals.append(get_all_platinum_bolts_victory_condition())
+    if VictoryConditions.get_all_weapons in goals_options:
+        ctx.goals.append(get_all_weapons_victory_condition())
+    if VictoryConditions.get_all_gadgets in goals_options:
+        ctx.goals.append(get_all_gadgets_victory_condition())
+
+
 async def _handle_game_ready(ctx: Rac2Context):
+    if len(ctx.goals) is 0:
+        initialize_goals(ctx)
+
     if ctx.is_loading:
         if not ctx.game_interface.is_loading():
             ctx.is_loading = False

--- a/Rac2Options.py
+++ b/Rac2Options.py
@@ -6,6 +6,7 @@ from Options import (
     DefaultOnToggle,
     Toggle,
     Range,
+    OptionSet,
 )
 from dataclasses import dataclass
 
@@ -117,6 +118,28 @@ class FirstPersonModeGlitchInLogic(Choice):
     default = 0
 
 
+class VictoryConditions(OptionSet):
+    """Determines the objectives of the run.
+    The list of objectives is as follows:
+    - Defeat the Mutated Protopet
+    - Get all Platinum Bolts
+    - Get all Weapons
+    - Get all Gadgets
+    Note: if the list is empty, the objective will default to "Defeat the Mutated Protopet"."""
+    display_name = "Victory Conditions"
+    defeat_protopet = "Defeat the Mutated Protopet"
+    get_all_platinum_bolts = "Get all Platinum Bolts"
+    get_all_weapons = "Get all Weapons"
+    get_all_gadgets = "Get all Gadgets"
+    valid_keys = {
+        defeat_protopet,
+        get_all_platinum_bolts,
+        get_all_weapons,
+        get_all_gadgets,
+    }
+    default = { defeat_protopet }
+
+
 @dataclass
 class Rac2Options(PerGameCommonOptions):
     start_inventory_from_pool: StartInventoryPool
@@ -135,3 +158,4 @@ class Rac2Options(PerGameCommonOptions):
     extra_spaceship_challenge_locations: ExtraSpaceshipChallengeLocations
     extend_weapon_progression: ExtendWeaponProgression
     first_person_mode_glitch_in_logic: FirstPersonModeGlitchInLogic
+    victory_conditions: VictoryConditions

--- a/Simplified Ratchet & Clank 2.yaml
+++ b/Simplified Ratchet & Clank 2.yaml
@@ -109,6 +109,18 @@ Ratchet & Clank 2:
   # Can be disabled with value disabled.
   first_person_mode_glitch_in_logic: disabled
 
+  # Determines the objectives of the run.
+  # The list of objectives is as follows:
+  #    - Defeat the Mutated Protopet
+  #    - Get all Platinum Bolts
+  #    - Get all Weapons
+  #    - Get all Gadgets
+  # Note: if the list is empty, the objective will default to "Defeat the Mutated Protopet".
+  victory_conditions:
+    [
+      "Defeat the Mutated Protopet"
+    ]
+
   # Item & Location Options
   local_items:
     # Forces these items to be in their native world.

--- a/__init__.py
+++ b/__init__.py
@@ -7,6 +7,7 @@ import settings
 from worlds.AutoWorld import World, WebWorld
 from BaseClasses import Item, Tutorial, ItemClassification
 
+from .Rac2Options import VictoryConditions
 from . import ItemPool
 from .data import Items, Locations, Planets
 from .data.Items import EquipmentData
@@ -95,7 +96,7 @@ class Rac2World(World):
         if override:
             return Rac2Item(name, override, self.item_name_to_id[name], self.player)
         item_data = Items.from_name(name)
-        return Rac2Item(name, ItemPool.get_classification(item_data), self.item_name_to_id[name], self.player)
+        return Rac2Item(name, ItemPool.get_classification(item_data, self.options), self.item_name_to_id[name], self.player)
 
     def create_event(self, name: str) -> "Item":
         return Rac2Item(name, ItemClassification.progression, None, self.player)
@@ -118,15 +119,54 @@ class Rac2World(World):
         remain = len(unfilled) - len(items_to_add)
         assert remain >= 0, "There are more items than locations. This is not supported."
         print(f"[RAC2 Debug] Not enough items to fill all locations. Adding {remain} filler items to the item pool")
+        if VictoryConditions.defeat_protopet not in self.options.victory_conditions: # TODO rework this to better handle the mutated protopet check
+            remain += 1
         for _ in range(remain):
             items_to_add.append(self.create_item(Items.BOLT_PACK.name, ItemClassification.filler))
 
         self.multiworld.itempool += items_to_add
 
+    def get_mutated_protopet_victory_condition(self) -> Any:
+        location_name = Locations.YEEDIL_DEFEAT_MUTATED_PROTOPET.name
+        boss_location = self.multiworld.get_location(location_name, self.player)
+        boss_location.place_locked_item(self.create_event(location_name))
+        return lambda state, p=self.player, ev=location_name: state.has(ev, p)
+
+    def get_all_platinum_bolts_victory_condition(self) -> Any:
+        return lambda state: state.has(Items.PLATINUM_BOLT.name, self.player, 40)
+
+    def get_all_weapons_victory_condition(self) -> Any:
+        return lambda state: all(
+            state.has(item.name, self.player) for item in Items.LV1_WEAPONS
+        )
+
+    def get_all_gadgets_victory_condition(self) -> Any:
+        return lambda state: all(
+            state.has(item.name, self.player) for item in Items.EQUIPMENT
+        )
+
     def set_rules(self) -> None:
-        boss_location = self.multiworld.get_location(Locations.YEEDIL_DEFEAT_MUTATED_PROTOPET.name, self.player)
-        boss_location.place_locked_item(self.create_event("Victory"))
-        self.multiworld.completion_condition[self.player] = lambda state: state.has("Victory", self.player)
+        goals_options = self.options.victory_conditions
+
+        goals = []
+
+        if VictoryConditions.defeat_protopet in goals_options:
+            goals.append(self.get_mutated_protopet_victory_condition())
+        if VictoryConditions.get_all_platinum_bolts in goals_options:
+            goals.append(self.get_all_platinum_bolts_victory_condition())
+        if VictoryConditions.get_all_weapons in goals_options:
+            goals.append(self.get_all_weapons_victory_condition())
+        if VictoryConditions.get_all_gadgets in goals_options:
+            goals.append(self.get_all_gadgets_victory_condition())
+
+        if not goals:
+            boss_location = self.multiworld.get_location(Locations.YEEDIL_DEFEAT_MUTATED_PROTOPET.name, self.player)
+            boss_location.place_locked_item(self.create_event("Victory"))
+            self.multiworld.completion_condition[self.player] = lambda state: state.has("Victory", self.player)
+        else:
+            self.multiworld.completion_condition[self.player] = lambda state: all(
+                check(state) for check in goals
+            )
 
     def generate_output(self, output_directory: str) -> None:
         aprac2 = Rac2ProcedurePatch(player=self.player, player_name=self.multiworld.get_player_name(self.player))

--- a/__init__.py
+++ b/__init__.py
@@ -184,6 +184,7 @@ class Rac2World(World):
             "randomize_megacorp_vendor",
             "randomize_gadgetron_vendor",
             "extend_weapon_progression",
+            "victory_conditions"
         )
 
     def fill_slot_data(self) -> Mapping[str, Any]:


### PR DESCRIPTION
This PR adds the option to have multiple goals.
With this PR, 3 goals have been added:
- Get all weapons
- Get all gadgets
- Get all platinum bolts

When the platinum bolts goal is in the list, I force 40 bolts to be added in the multiworld, instead of 20.

If no goal is listed, it defaults to the classic one.

Note: I do not know how to handle the protopet fight check, so as of the writing of the PR, the check does not give anything.