### PR TITLE
Add startable coordinates option

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 from BaseClasses import ItemClassification, Item
 from .data import Items, Locations
 from .data.Items import CoordData, EquipmentData, ProgressiveUpgradeData, ItemData
-from .Rac2Options import StartingWeapons
+from .Rac2Options import StartableCoords, StartingWeapons
 
 if TYPE_CHECKING:
     from . import Rac2World
@@ -56,7 +56,13 @@ def create_planets(world: "Rac2World") -> list["Item"]:
     # If the player manually added any eligible coords to their starting inventory, those will get used first.
     # If there are still less than 3, pick the rest of the starting coords randomly from the eligible coords.
     starting_coords: list[CoordData] = [coord for coord in coords_to_add if coord.item_id in precollected_ids]
-    startable_coords: list[CoordData] = [coord for coord in Items.STARTABLE_COORDS if coord not in starting_coords]
+
+    startable_coords_option: list[str] = world.options.startable_coords.value
+    if len(starting_coords) + len(startable_coords_option) < 3:
+        startable_coords_option = StartableCoords.default
+    eligible_coords: list[CoordData] = [c for c in Items.COORDS if c.name in startable_coords_option]
+    startable_coords: list[CoordData] = [coord for coord in eligible_coords if coord not in starting_coords]
+
     world.multiworld.random.shuffle(startable_coords)
     for coord in startable_coords[:max(3 - len(starting_coords), 0)]:
         starting_coords.append(coord)

--- a/Rac2Options.py
+++ b/Rac2Options.py
@@ -6,6 +6,7 @@ from Options import (
     DefaultOnToggle,
     Toggle,
     Range,
+    ItemSet,
 )
 from dataclasses import dataclass
 
@@ -117,6 +118,35 @@ class FirstPersonModeGlitchInLogic(Choice):
     default = 0
 
 
+class StartableCoords(ItemSet):
+    """List of coordinates you can start with.
+    You will get 3 out of those.
+    Note: if the combination of this list and your starting inventory leads to fewer than 3 coordinates, the list will default to Oozla, Maktar Nebula, Endako, Feltzin System, Notak and Todano."""
+    display_name = "Starting Coordinates Pool"
+    valid_keys = {
+        "Oozla Coordinates",
+        "Maktar Nebula Coordinates",
+        "Endako Coordinates",
+        "Barlow Coordinates",
+        "Feltzin System Coordinates",
+        "Notak Coordinates",
+        "Siberius Coordinates",
+        "Tabora Coordinates",
+        "Dobbo Coordinates",
+        "Hrugis Cloud Coordinates",
+        "Joba Coordinates",
+        "Todano Coordinates",
+        "Boldan Coordinates",
+        "Aranos Prison Coordinates",
+        "Gorn Coordinates",
+        "Snivelak Coordinates",
+        "Smolg Coordinates",
+        "Damosel Coordinates",
+        "Grelbin Coordinates",
+    }
+    default = { "Oozla Coordinates", "Maktar Nebula Coordinates", "Endako Coordinates", "Feltzin System Coordinates", "Notak Coordinates", "Todano Coordinates" }
+
+
 @dataclass
 class Rac2Options(PerGameCommonOptions):
     start_inventory_from_pool: StartInventoryPool
@@ -135,3 +165,4 @@ class Rac2Options(PerGameCommonOptions):
     extra_spaceship_challenge_locations: ExtraSpaceshipChallengeLocations
     extend_weapon_progression: ExtendWeaponProgression
     first_person_mode_glitch_in_logic: FirstPersonModeGlitchInLogic
+    startable_coords: StartableCoords

--- a/Simplified Ratchet & Clank 2.yaml
+++ b/Simplified Ratchet & Clank 2.yaml
@@ -109,6 +109,20 @@ Ratchet & Clank 2:
   # Can be disabled with value disabled.
   first_person_mode_glitch_in_logic: disabled
 
+  # List of coordinates you can start with.
+  # You will get 3 out of those.
+  # Note: if the combination of this list and your starting inventory leads to fewer than 3 coordinates,
+  # the list will default to Oozla, Maktar Nebula, Endako, Feltzin System, Notak and Todano.
+  startable_coords:
+    [
+      "Oozla Coordinates",
+      "Maktar Nebula Coordinates",
+      "Endako Coordinates",
+      "Feltzin System Coordinates",
+      "Notak Coordinates",
+      "Todano Coordinates"
+    ]
+
   # Item & Location Options
   local_items:
     # Forces these items to be in their native world.


### PR DESCRIPTION
This PR adds the option to list all the coordinates that can be started with.
If the yaml specifies less than 3 total coordinates between this new list and the starting inventory, the list defaults to Oozla, Maktar Nebula, Endako, Feltzin System, Notak and Todano.